### PR TITLE
fix: route 추가 + Header Modal error 해결 

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,20 +1,19 @@
-import { BrowserRouter as Router, Route, Routes } from "react-router-dom"; // react-router-dom 추가
+import { BrowserRouter as Router, Route, Routes } from "react-router-dom";
+
 import Header from "./routes/LayOut/Header";
 import Main from "./routes/Main/Main";
 import Mypage from "./routes/Mypage/Mypage";
-import EditorModal from "./components/editor/EditorModal";
-import BlogEditor from "./components/editor/BlogEditor";
-import useEditorStore from "./store/store";
-
+import Login from "./routes/Login/Login";
+import Join from "./routes/Join/Join";
 
 export default function App() {
-  const { isEditorOpen, toggleEditor, saveContent } = useEditorStore();
-
   return (
     <Router>
       <main className="px-[50px] mx-auto roboto-medium max-w-[1440px]">
         <Header />
         <Routes>
+          <Route path="/login" element={<Login />} />{" "}
+          <Route path="/join" element={<Join />} />
           <Route path="/" element={<Main />} />
           <Route path="/mypage" element={<Mypage />} />
         </Routes>

--- a/src/components/headerModal/Modal.tsx
+++ b/src/components/headerModal/Modal.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useRef } from "react";
 import { useHeaderModalStore } from "../../store/headerModalStore";
+import { Link } from "react-router-dom";
 
 export default function Modal() {
   const modalState = useHeaderModalStore((s) => s.modal);
@@ -27,7 +28,7 @@ export default function Modal() {
 
   return (
     <div ref={contentRef} className="absolute top-[4.5rem] right-[50px]">
-      <div className="h-52 drop-shadow-xl flex-col justify-center items-center inline-flex rounded-2xl bg-white">
+      <div className="inline-flex flex-col items-center justify-center bg-white h-52 drop-shadow-xl rounded-2xl">
         <div className="w-[305px] px-4 pt-[18px]  rounded-tl-2xl rounded-tr-2xl justify-start items-center gap-[89px] inline-flex">
           <div className="h-[60px] pr-[68px] pb-[18px] justify-start items-center gap-3 flex">
             <div className="w-[42px] h-[42px] relative">
@@ -55,15 +56,19 @@ export default function Modal() {
           <div className="w-[305px] h-[60px] px-2.5 py-1  flex-col justify-start items-start gap-2.5 flex">
             <div className="justify-start items-center gap-3.5 inline-flex">
               <div className="h-[52px] px-3.5 py-[15px] rounded-[14px] justify-start items-center gap-3 flex">
-                <div className="w-5 h-5 relative">
+                <div className="relative w-5 h-5">
                   <img
                     className="w-5 h-5 left-[2px] top-[2px] absolute"
                     src="/public/settings.svg"
                   />
                 </div>
-                <div className="text-black text-lg font-medium font-['Inter']">
+
+                <Link
+                  to="./mypage"
+                  className="text-black text-lg font-medium font-['Inter']"
+                >
                   내 프로필{" "}
-                </div>
+                </Link>
               </div>
             </div>
           </div>
@@ -72,7 +77,7 @@ export default function Modal() {
           <div className="w-[305px] h-[60px] px-2.5 py-1  flex-col justify-start items-start gap-2.5 flex">
             <div className="justify-start items-center gap-3.5 inline-flex">
               <div className="h-[52px] px-3.5 py-[15px] rounded-[14px] justify-start items-center gap-3 flex">
-                <div className="w-5 h-5 relative">
+                <div className="relative w-5 h-5">
                   <img
                     className="w-5 h-5 left-[2px] top-[2px] absolute"
                     src="/public/signout.svg"

--- a/src/components/headerModal/Modal.tsx
+++ b/src/components/headerModal/Modal.tsx
@@ -55,7 +55,7 @@ export default function Modal() {
         <a className="cursor-pointer">
           <div className="w-[305px] h-[60px] px-2.5 py-1  flex-col justify-start items-start gap-2.5 flex">
             <div className="justify-start items-center gap-3.5 inline-flex">
-              <div className="h-[52px] px-3.5 py-[15px] rounded-[14px] justify-start items-center gap-3 flex">
+              <div className="h-[52px] px-3.5 py-[15px] rounded-[14px] justify-center gap-3 flex">
                 <div className="relative w-5 h-5">
                   <img
                     className="w-5 h-5 left-[2px] top-[2px] absolute"
@@ -77,7 +77,7 @@ export default function Modal() {
         <a className="cursor-pointer">
           <div className="w-[305px] h-[60px] px-2.5 py-1  flex-col justify-start items-start gap-2.5 flex">
             <div className="justify-start items-center gap-3.5 inline-flex">
-              <div className="h-[52px] px-3.5 py-[15px] rounded-[14px] justify-start items-center gap-3 flex">
+              <div className="h-[52px] px-3.5 py-[15px] rounded-[14px] justify-center gap-3 flex">
                 <div className="relative w-5 h-5">
                   <img
                     className="w-5 h-5 left-[2px] top-[2px] absolute"

--- a/src/components/headerModal/Modal.tsx
+++ b/src/components/headerModal/Modal.tsx
@@ -84,9 +84,12 @@ export default function Modal() {
                     src="/public/signout.svg"
                   />
                 </div>
-                <div className="text-black text-lg font-medium font-['Inter']">
+                <Link
+                  to="./login"
+                  className="text-black text-lg font-medium font-['Inter']"
+                >
                   로그아웃
-                </div>
+                </Link>
               </div>
             </div>
           </div>

--- a/src/components/headerModal/Modal.tsx
+++ b/src/components/headerModal/Modal.tsx
@@ -66,8 +66,9 @@ export default function Modal() {
                 <Link
                   to="./mypage"
                   className="text-black text-lg font-medium font-['Inter']"
+                  onClick={close}
                 >
-                  내 프로필{" "}
+                  내 프로필
                 </Link>
               </div>
             </div>

--- a/src/routes/LayOut/Header.tsx
+++ b/src/routes/LayOut/Header.tsx
@@ -27,10 +27,7 @@ export default function Header() {
         <Link to="#">
           <img src={"/public/alarm_icon.svg"} alt={"알람 아이콘"} />
         </Link>
-        <Link
-          to="/mypage"
-          className={`w-[40px] h-[40px] rounded-full bg-[url(/public/profile.svg)] bg-center`}
-        ></Link>
+
         <button
           onClick={(e) => {
             e.stopPropagation();

--- a/src/routes/LayOut/Header.tsx
+++ b/src/routes/LayOut/Header.tsx
@@ -1,4 +1,4 @@
-import { useNavigate, Link } from "react-router-dom";
+import { Link } from "react-router-dom";
 import Modal from "../../components/headerModal/Modal";
 import { useHeaderModalStore } from "../../store/headerModalStore";
 

--- a/src/routes/Mypage/Mypage.tsx
+++ b/src/routes/Mypage/Mypage.tsx
@@ -66,7 +66,7 @@ const Mypage = () => {
   return (
     <section className="p-5 pt-8 overflow-hidden h-[100vh]">
       {/* 제목 */}
-      <article className="flex ml-10 mt-14">
+      <article className="flex mt-14">
         <h1 className="text-4xl font-bold">내 프로필</h1>
       </article>
 
@@ -77,13 +77,12 @@ const Mypage = () => {
           className="items-center"
           sx={{
             width: "fit",
-            marginLeft: "5rem",
           }}
         >
           <Box
             position="relative"
-            width={"22.5rem"}
-            height={"22.5rem"}
+            width="22.5rem"
+            height="22.5rem"
             mx="auto"
             mb={3}
             borderRadius="50%"
@@ -100,7 +99,7 @@ const Mypage = () => {
               src={isEditable ? tempProfilePic : profilePic}
               alt="Profile"
               style={{
-                width: '"100%"',
+                width: "100%",
                 height: "100%",
                 objectFit: "cover",
                 cursor: isEditable ? "pointer" : "not-allowed",


### PR DESCRIPTION
## 🪄 변경 사항
### Header Modal
- 우측에 프로필 버튼이 2개 보이는 error 해결 
- 클릭 후 마이페이지로 이동 시 Modal이 자동으로 닫히도록
- 버튼 가운데로 정렬 

### 마이페이지
- 화면 좌측에 공백이 생겨 margin 값 조정 

### Route 추가 
- 마이페이지
- 로그인
- 회원가입 
- 로그아웃 ➡️ 로그인 


## 💡 반영 브랜치
fix/header-route ➡️ main

## 🖼️ 결과 화면 (생략 가능)

## 💬 리뷰어에게 전할 말
화이팅 (❁´◡`❁)