### PR TITLE
🐛 fix: 타이머 로컬스토리지 관련 버그 수정

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -12,6 +12,9 @@ export default function App() {
     if (!localStorage.getItem("ToDoList")) {
       localStorage.setItem("ToDoList", "[]");
     }
+    if (!localStorage.getItem("TimerTime")) {
+      localStorage.setItem("TimerTime", JSON.stringify([0, 0, 0]));
+    }
   }, []);
   return (
     <Router>

--- a/src/components/Mui/Fab.tsx
+++ b/src/components/Mui/Fab.tsx
@@ -19,9 +19,6 @@ export default function FloatingActionButtons() {
   const seconds = useTimerStore((state) => state.seconds);
 
   React.useEffect(() => {
-    if (!localStorage.getItem("TimerTime")) {
-      localStorage.setItem("TimerTime", JSON.stringify([0, 0, 0]));
-    }
     // 시계 동작
     let Active: number;
     if (isTimerActive) {

--- a/src/components/howTime/HowTimeContents/HowTimeUnder.tsx
+++ b/src/components/howTime/HowTimeContents/HowTimeUnder.tsx
@@ -1,3 +1,4 @@
+import { useHowTimeStore } from "../../../store/store";
 import Button from "../../common/Button";
 
 export default function HowTimeUnder() {
@@ -11,7 +12,7 @@ export default function HowTimeUnder() {
       <Button size="sm" variant="custom" textSize="md" className="">
         좋아요 🔥
       </Button>
-      <Button size="md" variant="custom" textSize="md" className="">
+      <Button size="md" variant="custom" textSize="md">
         다시 할래요 🤔
       </Button>
     </article>

--- a/src/components/howTime/HowTimeModal.tsx
+++ b/src/components/howTime/HowTimeModal.tsx
@@ -13,7 +13,10 @@ export default function HowTimeModal() {
   const randomTime = Math.floor(Math.random() * 24 + 1).toString();
   // 난수 몇 번 반복하는지
   const [count, setCount] = useState(10);
-  const [howTimeHoursSet, setHowTimeHoursSet] = useState("0");
+  const setHowTimeHoursSet = useHowTimeStore(
+    (state) => state.setHowTimeHoursSet
+  );
+  const howTimeHoursSet = useHowTimeStore((state) => state.howTimeHoursSet);
 
   useEffect(() => {
     const intervalId = setInterval(() => {
@@ -25,7 +28,7 @@ export default function HowTimeModal() {
       }
     }, 50);
     return () => clearInterval(intervalId);
-  }, [howTimeHoursSet, count]);
+  }, [howTimeHoursSet, count, setHowTimeHoursSet]);
 
   return (
     <section className="w-full h-full block absolute left-0 top-0 z-40">

--- a/src/store/store.ts
+++ b/src/store/store.ts
@@ -25,10 +25,14 @@ export default useEditorStore;
 // 메인페이지 몇 시간? 클릭시 상호작용 기능
 interface HowTimeState {
   isHowTimeOpen: boolean;
+  howTimeHoursSet: string;
+  setHowTimeHoursSet: (random: string) => void;
   toggleHowTime: () => void;
 }
 export const useHowTimeStore = create<HowTimeState>((set) => ({
   isHowTimeOpen: false,
+  howTimeHoursSet: "0",
+  setHowTimeHoursSet: (random) => set(() => ({ howTimeHoursSet: random })),
   toggleHowTime: () =>
     set((state) => ({
       isHowTimeOpen: !state.isHowTimeOpen,
@@ -109,9 +113,15 @@ interface TimerStorage {
   activeTimer: () => void;
 }
 export const useTimerStore = create<TimerStorage>((set) => ({
-  hours: JSON.parse(localStorage.getItem("TimerTime")!)[0],
-  minutes: JSON.parse(localStorage.getItem("TimerTime")!)[1],
-  seconds: JSON.parse(localStorage.getItem("TimerTime")!)[2],
+  hours: localStorage.getItem("TimerTime")
+    ? JSON.parse(localStorage.getItem("TimerTime")!)[0]
+    : 0,
+  minutes: localStorage.getItem("TimerTime")
+    ? JSON.parse(localStorage.getItem("TimerTime")!)[1]
+    : 0,
+  seconds: localStorage.getItem("TimerTime")
+    ? JSON.parse(localStorage.getItem("TimerTime")!)[2]
+    : 0,
   isTimerActive: false,
   toggleTimer: () => set((state) => ({ isTimerActive: !state.isTimerActive })),
   activeTimer: () => {


### PR DESCRIPTION
## 🪄 변경 사항
1. 타이머 로컬스토리지 초기 설정을 루트폴더인 App.tsx에 하지 않고 Fab에 생성했음 
- => App.tsx파일로 옮김 
2.  useTimerStore의 시간값 초기설정에서 localStorage가 최초 생성되기 전에 store파일이 읽혀서 localStorage의 값을 찾을 수 없었음 
- => 예외 처리 했음(localStorage.getItem("TimerTime")
    ? JSON.parse(localStorage.getItem("TimerTime")!)[0])

## 💡 반영 브랜치
- feat/post-main-fix

## 🖼️ 결과 화면 (생략 가능)
![image](https://github.com/user-attachments/assets/ec6c9ec6-4ca5-418e-9b05-7805f7c92f5e)

## 💬 리뷰어에게 전할 말
- 짜잔