### PR TITLE
✅ feat/post-main: 메인페이지 타이머 기능 정형화 + 목표시간 추가 + 변수명, storage 대거 변경

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -15,6 +15,12 @@ export default function App() {
     if (!localStorage.getItem("TimerTime")) {
       localStorage.setItem("TimerTime", JSON.stringify([0, 0, 0]));
     }
+    if (!localStorage.getItem("StaticTimerTime")) {
+      localStorage.setItem(
+        "StaticTimerTime",
+        JSON.stringify(["00", "00", "00"])
+      );
+    }
   }, []);
   return (
     <Router>

--- a/src/components/Mui/Fab.tsx
+++ b/src/components/Mui/Fab.tsx
@@ -8,6 +8,9 @@ import NavigationIcon from "@mui/icons-material/Navigation";
 import { createTheme, styled } from "@mui/material";
 import { useTimerPlayStore, useTimerStore } from "../../store/store";
 
+// active에 값이 있으면 실행을 정지
+let Active: number = 0;
+
 export default function FloatingActionButtons() {
   const isPlayBtnClicked = useTimerPlayStore((state) => state.isPlayBtnClicked);
   const togglePlayBtn = useTimerPlayStore((state) => state.togglePlayBtn);
@@ -20,11 +23,12 @@ export default function FloatingActionButtons() {
 
   React.useEffect(() => {
     // 시계 동작
-    let Active: number;
     if (isTimerActive) {
-      Active = setInterval(() => {
-        activeTimer();
-      }, 1000);
+      if (Active === 0) {
+        Active = setInterval(() => {
+          activeTimer();
+        }, 1000);
+      }
       localStorage.setItem(
         "TimerTime",
         JSON.stringify([hours, minutes, seconds])
@@ -34,12 +38,16 @@ export default function FloatingActionButtons() {
       "TimerTime",
       JSON.stringify([hours, minutes, seconds])
     );
+    if (!isTimerActive) {
+      clearTimeout(Active);
+      Active = 0;
+      console.log(Active);
+    }
     return () => {
       localStorage.setItem(
         "TimerTime",
         JSON.stringify([hours, minutes, seconds])
       );
-      clearInterval(Active);
     };
   }, [isTimerActive, activeTimer]);
 

--- a/src/components/howTime/HowTimeContents/HowTimeContents.tsx
+++ b/src/components/howTime/HowTimeContents/HowTimeContents.tsx
@@ -3,15 +3,17 @@ import HowTimeTop from "./HowTimeTop";
 import HowTimeUnder from "./HowTimeUnder";
 
 export default function HowTimeContents({
-  howTimeHoursSet,
+  changingHours,
+  setRestart,
 }: {
-  howTimeHoursSet: string;
+  changingHours: string;
+  setRestart: (e: React.SetStateAction<number>) => void;
 }) {
   return (
-    <article className="px-[50px] py-[30px]">
-      <HowTimeTop howTimeHoursSet={howTimeHoursSet} />
-      <HowTimeTimer howTimeHoursSet={howTimeHoursSet} />
-      <HowTimeUnder />
-    </article>
+    <>
+      <HowTimeTop changingHours={changingHours} />
+      <HowTimeTimer changingHours={changingHours} />
+      {/* <HowTimeUnder setRestart={setRestart} /> */}
+    </>
   );
 }

--- a/src/components/howTime/HowTimeContents/HowTimeContents.tsx
+++ b/src/components/howTime/HowTimeContents/HowTimeContents.tsx
@@ -4,7 +4,6 @@ import HowTimeUnder from "./HowTimeUnder";
 
 export default function HowTimeContents({
   changingHours,
-  setRestart,
 }: {
   changingHours: string;
   setRestart: (e: React.SetStateAction<number>) => void;

--- a/src/components/howTime/HowTimeContents/HowTimeTimer.tsx
+++ b/src/components/howTime/HowTimeContents/HowTimeTimer.tsx
@@ -1,18 +1,13 @@
 import Timer from "../../../routes/Main/LeftContents/TimerComponent/Timer";
 
 export default function HowTimeTimer({
-  howTimeHoursSet,
+  changingHours,
 }: {
-  howTimeHoursSet: string;
+  changingHours: string;
 }) {
   return (
     <article className="w-full flex items-center justify-center mt-[30px] translate-y-[30px] opacity-0 animate-fadeIn_1s">
-      <Timer
-        style={{}}
-        staticHours={howTimeHoursSet}
-        staticMinuites="00"
-        staticSeconds="00"
-      />
+      <Timer style={{}} changingHours={changingHours} isStaticTime={true} />
     </article>
   );
 }

--- a/src/components/howTime/HowTimeContents/HowTimeTop.tsx
+++ b/src/components/howTime/HowTimeContents/HowTimeTop.tsx
@@ -1,12 +1,12 @@
 export default function HowTimeTop({
-  howTimeHoursSet,
+  changingHours,
 }: {
-  howTimeHoursSet: string;
+  changingHours: string;
 }) {
   return (
     <article className="flex gap-[10px] text-[2.5rem] font-bold">
       <span>총</span>
-      <span>{howTimeHoursSet}</span>
+      <span>{changingHours}</span>
       <span>시간!!</span>
     </article>
   );

--- a/src/components/howTime/HowTimeContents/HowTimeUnder.tsx
+++ b/src/components/howTime/HowTimeContents/HowTimeUnder.tsx
@@ -1,7 +1,12 @@
+// 일단 이 컴포넌트 페이지 보류입니다.(다시할래요 버튼으로 모달창 애니메이션을 조작할 수 없어서 모달창에 통째로 꺼냈습니다.)
 import { useHowTimeStore } from "../../../store/store";
 import Button from "../../common/Button";
 
-export default function HowTimeUnder() {
+export default function HowTimeUnder({
+  setRestart,
+}: {
+  setRestart: (e: React.SetStateAction<number>) => void;
+}) {
   return (
     <article className="flex flex-col items-center gap-5 translate-y-[30px] opacity-0 animate-fadeIn_2s">
       <span className="text-[40px] font-bold ">
@@ -12,7 +17,14 @@ export default function HowTimeUnder() {
       <Button size="sm" variant="custom" textSize="md" className="">
         좋아요 🔥
       </Button>
-      <Button size="md" variant="custom" textSize="md">
+      <Button
+        size="md"
+        variant="custom"
+        textSize="md"
+        onClick={() => {
+          setRestart((e) => e + 1);
+        }}
+      >
         다시 할래요 🤔
       </Button>
     </article>

--- a/src/components/howTime/HowTimeModal.tsx
+++ b/src/components/howTime/HowTimeModal.tsx
@@ -1,11 +1,12 @@
 import React, { useEffect, useState } from "react";
-import { useHowTimeStore } from "../../store/store";
+import { useHowTimeStore, useTimerStore } from "../../store/store";
 import Timer from "../../routes/Main/LeftContents/TimerComponent/Timer";
 import HowTimeTimer from "./HowTimeContents/HowTimeTimer";
 import HowTimeUnder from "./HowTimeContents/HowTimeUnder";
 import HowTimeTop from "./HowTimeContents/HowTimeTop";
 import HowTimeHeader from "./howTimeHeader/HowTimeHeader";
 import HowTimeContents from "./HowTimeContents/HowTimeContents";
+import Button from "../common/Button";
 
 export default function HowTimeModal() {
   const toggleHowTime = useHowTimeStore((state) => state.toggleHowTime);
@@ -13,22 +14,25 @@ export default function HowTimeModal() {
   const randomTime = Math.floor(Math.random() * 24 + 1).toString();
   // 난수 몇 번 반복하는지
   const [count, setCount] = useState(10);
-  const setHowTimeHoursSet = useHowTimeStore(
-    (state) => state.setHowTimeHoursSet
-  );
-  const howTimeHoursSet = useHowTimeStore((state) => state.howTimeHoursSet);
+  const [restart, setRestart] = useState(0);
+  const setChangingHours = useHowTimeStore((state) => state.setChangingHours);
+  const changingHours = useHowTimeStore((state) => state.changingHours);
+
+  const setStaticHours = useTimerStore((state) => state.setStaticHours);
+  const setStaticMinuites = useTimerStore((state) => state.setStaticMinuites);
+  const setStaticSeconds = useTimerStore((state) => state.setStaticSeconds);
 
   useEffect(() => {
     const intervalId = setInterval(() => {
       if (count > 0) {
-        setHowTimeHoursSet(randomTime);
+        setChangingHours(randomTime);
         setCount(count - 1);
       } else {
         clearInterval(intervalId);
       }
     }, 50);
     return () => clearInterval(intervalId);
-  }, [howTimeHoursSet, count, setHowTimeHoursSet]);
+  }, [changingHours, count]);
 
   return (
     <section className="w-full h-full block absolute left-0 top-0 z-40">
@@ -38,7 +42,47 @@ export default function HowTimeModal() {
       ></div>
       <article className="w-full max-w-[1152px] h-[819px] bg-white absolute top-[50%] left-[50%] translate-x-[-50%] translate-y-[-50%] z-50 rounded-[10px]">
         <HowTimeHeader />
-        <HowTimeContents howTimeHoursSet={howTimeHoursSet} />
+        <article className="px-[50px] py-[30px]">
+          <HowTimeContents
+            changingHours={changingHours}
+            setRestart={setRestart}
+          />
+          <article className="flex flex-col items-center gap-5 translate-y-[30px] opacity-0 animate-fadeIn_2s">
+            <span className="text-[40px] font-bold ">
+              자, 이제 공부하러 가볼까요? 📖
+            </span>
+
+            {/* 기타 CSS 지정해야 합니다! */}
+            <Button
+              size="sm"
+              variant="custom"
+              textSize="md"
+              onClick={() => {
+                setStaticHours(changingHours);
+                setStaticMinuites("00");
+                setStaticSeconds("00");
+                localStorage.setItem(
+                  "StaticTimerTime",
+                  JSON.stringify([changingHours, "00", "00"])
+                );
+                toggleHowTime();
+              }}
+            >
+              좋아요 🔥
+            </Button>
+            <Button
+              size="md"
+              variant="custom"
+              textSize="md"
+              onClick={() => {
+                // 다시 count 0 에서 10으로 변경해 랜덤시간 재실행
+                setCount(() => 10);
+              }}
+            >
+              다시 할래요 🤔
+            </Button>
+          </article>
+        </article>
       </article>
     </section>
   );

--- a/src/routes/Main/LeftContents/TimerComponent/Timer.tsx
+++ b/src/routes/Main/LeftContents/TimerComponent/Timer.tsx
@@ -5,45 +5,71 @@ interface TimerType {
     backgroundColor?: string;
     color?: string;
   };
-  staticHours?: string;
-  staticMinuites?: string;
-  staticSeconds?: string;
+  changingHours?: string;
+  isStaticTime?: boolean;
+  isFlowTime?: boolean;
 }
 
 export default function Timer({
   style,
-  staticHours,
-  staticMinuites,
-  staticSeconds,
+  changingHours,
+  isStaticTime = false,
+  isFlowTime = false,
 }: TimerType) {
   const hours = useTimerStore((state) => state.hours);
   const minutes = useTimerStore((state) => state.minutes);
   const seconds = useTimerStore((state) => state.seconds);
+  const staticHours = useTimerStore((state) => state.staticHours);
+  const staticMinuites = useTimerStore((state) => state.staticMinuites);
+  const staticSeconds = useTimerStore((state) => state.staticSeconds);
   return (
     <>
       <article
-        className={`timer-shadow flex items-center justify-center w-[25rem] h-[25rem] rounded-full bg-[#F0F5F8] mb-5 transition-colors duration-200`}
+        className={`timer-shadow flex flex-col gap-[10px] items-center justify-center w-[25rem] h-[25rem] rounded-full bg-[#F0F5F8] mb-5 transition-colors duration-200`}
         style={style}
       >
-        <article className="flex gap-1 text-5xl">
-          {staticHours ? (
-            <span>{staticHours}</span>
-          ) : (
-            <span>{hours < 10 ? `0${hours}` : hours}</span>
-          )}
-          <span>:</span>
-          {staticMinuites ? (
-            <span>{staticMinuites}</span>
-          ) : (
-            <span>{minutes < 10 ? `0${minutes}` : minutes}</span>
-          )}
-          <span>:</span>
-          {staticSeconds ? (
-            <span>{staticSeconds}</span>
-          ) : (
-            <span>{seconds < 10 ? `0${seconds}` : seconds}</span>
-          )}
-        </article>
+        {isStaticTime ? (
+          <>
+            <article className="flex gap-1 text-4xl text-gray-400">
+              <span>{changingHours}</span>
+
+              <span>:</span>
+
+              <span>{staticMinuites}</span>
+
+              <span>:</span>
+
+              <span>{staticSeconds}</span>
+            </article>
+          </>
+        ) : null}
+        {isFlowTime ? (
+          <>
+            <article className="flex gap-1 text-4xl text-gray-400">
+              <span>{staticHours}</span>
+
+              <span>:</span>
+
+              <span>{staticMinuites}</span>
+
+              <span>:</span>
+
+              <span>{staticSeconds}</span>
+            </article>
+            <span className="text-[20px] font-black">ㅡ</span>
+            <article className="flex gap-1 text-5xl mt-[15px]">
+              <span>{hours < 10 ? `0${hours}` : hours}</span>
+
+              <span>:</span>
+
+              <span>{minutes < 10 ? `0${minutes}` : minutes}</span>
+
+              <span>:</span>
+
+              <span>{seconds < 10 ? `0${seconds}` : seconds}</span>
+            </article>
+          </>
+        ) : null}
       </article>
     </>
   );

--- a/src/routes/Main/LeftContents/TimerComponent/TimerComponent.tsx
+++ b/src/routes/Main/LeftContents/TimerComponent/TimerComponent.tsx
@@ -11,6 +11,7 @@ export default function TimerComponent() {
           backgroundColor: `${isPlayBtnClicked ? "#778899" : ""}`,
           color: `${isPlayBtnClicked ? "#ffffff" : ""}`,
         }}
+        isFlowTime={true}
       />
       <FloatingActionButtons />
     </>

--- a/src/store/store.ts
+++ b/src/store/store.ts
@@ -25,14 +25,14 @@ export default useEditorStore;
 // 메인페이지 몇 시간? 클릭시 상호작용 기능
 interface HowTimeState {
   isHowTimeOpen: boolean;
-  howTimeHoursSet: string;
-  setHowTimeHoursSet: (random: string) => void;
+  changingHours: string;
+  setChangingHours: (random: string) => void;
   toggleHowTime: () => void;
 }
 export const useHowTimeStore = create<HowTimeState>((set) => ({
   isHowTimeOpen: false,
-  howTimeHoursSet: "0",
-  setHowTimeHoursSet: (random) => set(() => ({ howTimeHoursSet: random })),
+  changingHours: "0",
+  setChangingHours: (random) => set(() => ({ changingHours: random })),
   toggleHowTime: () =>
     set((state) => ({
       isHowTimeOpen: !state.isHowTimeOpen,
@@ -116,6 +116,12 @@ interface TimerStorage {
   hours: number;
   minutes: number;
   seconds: number;
+  staticHours: string;
+  staticMinuites: string;
+  staticSeconds: string;
+  setStaticHours: (change: string) => void;
+  setStaticMinuites: (change: string) => void;
+  setStaticSeconds: (change: string) => void;
   isTimerActive: boolean;
   toggleTimer: () => void;
   activeTimer: () => void;
@@ -130,6 +136,18 @@ export const useTimerStore = create<TimerStorage>((set) => ({
   seconds: localStorage.getItem("TimerTime")
     ? JSON.parse(localStorage.getItem("TimerTime")!)[2]
     : 0,
+  staticHours: localStorage.getItem("StaticTimerTime")
+    ? JSON.parse(localStorage.getItem("StaticTimerTime")!)[0]
+    : "00",
+  staticMinuites: localStorage.getItem("StaticTimerTime")
+    ? JSON.parse(localStorage.getItem("StaticTimerTime")!)[1]
+    : "00",
+  staticSeconds: localStorage.getItem("StaticTimerTime")
+    ? JSON.parse(localStorage.getItem("StaticTimerTime")!)[2]
+    : "00",
+  setStaticHours: (change) => set(() => ({ staticHours: change })),
+  setStaticMinuites: (change) => set(() => ({ staticMinuites: change })),
+  setStaticSeconds: (change) => set(() => ({ staticSeconds: change })),
   isTimerActive: false,
   toggleTimer: () => set((state) => ({ isTimerActive: !state.isTimerActive })),
   activeTimer: () => {


### PR DESCRIPTION
## 🪄 변경 사항
- 메인 페이지에 타이머 기능이 일부 활성화 되었습니다.(카운트 업 방식의 카운팅 기능)
- 타이머의 카운팅 기능이 라우팅 페이지 이동시 멈추는 현상을 수정했습니다(강사님이 도와주심, 하지만 인터벌 저장 변수가 컴포넌트 밖에 생성되어 있어 추후 zustand store에 따로 관리할 예정)
- 목표 시간 기능이 추가 되었습니다. 이제 몇 시간? 기능으로 정해진 시간을 목표시간으로 설정할 수 있습니다.(localStorage 활용, 추후에 오늘의 목표 설정하기 기능으로 목표시간 커스텀 기능 추가 예정) 
- 목표 시간을 활용해 추후에 목표 달성시 타이머 ui가 변하고 달성 여부를 boolean값으로 storage에 저장해 API에 저장시켜 사용할까 생각중입니다.
- 기능 개발하면서 각종 변수, storage형태가 변경되었습니다.(howTimeHoursSet, setHowTimeHoursSet 변수명 전부 changingHours, setChangingHours로 변경)

## 💡 반영 브랜치
- feat/post-main

## 🖼️ 결과 화면 (생략 가능)
![image](https://github.com/user-attachments/assets/e040fdc0-cf02-4de1-abdd-60f9b221385e)
![image](https://github.com/user-attachments/assets/1003dea3-777b-496e-9282-93d6168141e7)
![image](https://github.com/user-attachments/assets/b379faf9-0fb5-49db-945b-c68f5242788b)
- port가 끊겨서 이미지 등이 안보입니당

## 💬 리뷰어에게 전할 말
- 제발 컴플릿 없기를......🙏🙏🙏
