### PR TITLE
fix: 에디터를 닫을 때, 제대로 안닫히는 현상 수정

### DIFF
--- a/src/components/editor/EditorModal.tsx
+++ b/src/components/editor/EditorModal.tsx
@@ -18,7 +18,7 @@ export default function EditorModal({ children }: ModalProps) {
   } = useEditorStore();
 
   const handleCancel = () => {
-    if (content.trim() || title.trim()) {
+    if ((content.trim() && content.trim() !== "<p><br></p>") || title.trim()) {
       toggleDialog(true); // ConfirmDialog 열기
     } else {
       resetEditor();

--- a/src/routes/Main/LeftContents/ButtonListComponent/ButtonListComponent.tsx
+++ b/src/routes/Main/LeftContents/ButtonListComponent/ButtonListComponent.tsx
@@ -1,24 +1,24 @@
 import { useEditorStore } from "../../../../store/store";
 import { useHowTimeStore } from "../../../../store/store";
 import LinkButton from "./LinkButton";
-// import EditorModal from "../../../../components/editor/EditorModal";
-// import BlogEditor from "../../../../components/editor/BlogEditor";
+import EditorModal from "../../../../components/editor/EditorModal";
+import BlogEditor from "../../../../components/editor/BlogEditor";
 
 export default function ButtonListComponent() {
-  // const { toggleEditor } = useEditorStore();
+  const { toggleEditor } = useEditorStore();
   const { toggleHowTime } = useHowTimeStore();
 
-  // const saveContent = (content: string) => {
-  //   console.log("출간된 내용:", content);
-  //   toggleEditor();
-  // };
+  const saveContent = (content: string) => {
+    console.log("출간된 내용:", content);
+    toggleEditor();
+  };
 
   return (
     <section className="flex gap-[20px]">
       <LinkButton
         icon={"./Edit.svg"}
         title={"글 작성"}
-        // onClick={toggleEditor}
+        onClick={toggleEditor}
       />
       <LinkButton icon={"./Chat.svg"} title={"게시판"} />
       <LinkButton icon={"./Group-person.svg"} title={"친구관리"} />
@@ -27,9 +27,9 @@ export default function ButtonListComponent() {
         title={"몇시간?"}
         onClick={toggleHowTime}
       />
-      {/* <EditorModal>
+      <EditorModal>
         <BlogEditor onSave={saveContent} />
-      </EditorModal> */}
+      </EditorModal>
     </section>
   );
 }


### PR DESCRIPTION
## 🪄 변경 사항

에디터를 닫을 때 `<p><br></p>` 가 생성 되어서
handleCancel 함수가 제대로 적용되지 않는 현상 수정.
ConfirmDialog가 제대로 출력됩니다.


## 💡 반영 브랜치
fix/editor
## 🖼️ 결과 화면 (생략 가능)

## 💬 리뷰어에게 전할 말

에디터 부분의 주석처리가 없습니다. 
리액트 버전 확인해주세요!
