### PR TITLE
💄 feat/post-main-style : 메인페이지 디자인 변경 + 필요없는 폴더, 코드 삭제

### DIFF
--- a/src/components/Mui/Calender.tsx
+++ b/src/components/Mui/Calender.tsx
@@ -4,9 +4,23 @@ import { AdapterDayjs } from "@mui/x-date-pickers/AdapterDayjs";
 import { DateCalendar } from "@mui/x-date-pickers";
 
 export default function BasicDateCalendar() {
+  const Styles = {
+    list: {
+      width: "100%",
+      borderRadius: "10px",
+      bgcolor: "#F0F5F8",
+      "& .MuiButtonBase-root.Mui-selected": {
+        backgroundColor: "#7EACB5",
+      },
+      "& .MuiPickersDay-today": {},
+    },
+  };
+
   return (
-    <LocalizationProvider dateAdapter={AdapterDayjs}>
-      <DateCalendar />
-    </LocalizationProvider>
+    <article className="shadow-2xl rounded-[10px]">
+      <LocalizationProvider dateAdapter={AdapterDayjs}>
+        <DateCalendar sx={Styles.list} />
+      </LocalizationProvider>
+    </article>
   );
 }

--- a/src/components/Mui/Fab.tsx
+++ b/src/components/Mui/Fab.tsx
@@ -42,7 +42,6 @@ export default function FloatingActionButtons() {
     if (!isTimerActive) {
       clearTimeout(Active);
       Active = 0;
-      console.log(Active);
     }
     return () => {
       localStorage.setItem(

--- a/src/components/Mui/List.tsx
+++ b/src/components/Mui/List.tsx
@@ -7,6 +7,7 @@ import ListItemAvatar from "@mui/material/ListItemAvatar";
 import Avatar from "@mui/material/Avatar";
 import { useHeaderModalStore } from "../../store/store";
 import Modal from "../headerModal/Modal";
+import { BorderBottom } from "@mui/icons-material";
 
 // 친구목록에 사용하는 리스트 MUI
 export default function CheckboxListSecondary() {
@@ -37,19 +38,39 @@ export default function CheckboxListSecondary() {
     setX(Math.floor(rect.top + window.scrollY) - 295);
   };
 
+  const styles = {
+    list: {
+      width: "100%",
+      maxWidth: 360,
+      bgcolor: "background.paper",
+      position: "relative",
+      overflow: "auto",
+      maxHeight: 205,
+      borderBottomLeftRadius: 10,
+      borderBottomRightRadius: 10,
+      "& ul": { padding: 0 },
+      /* 스크롤바 스타일 수정 */
+      "&::-webkit-scrollbar": {
+        width: "0px",
+      },
+      "&:hover::-webkit-scrollbar": {
+        width: "8px",
+      },
+      "&::-webkit-scrollbar-track": {
+        background: "#f1f1f1",
+      },
+      "&::-webkit-scrollbar-thumb": {
+        background: "#888",
+      },
+      "&::-webkit-scrollbar-thumb:hover": {
+        background: "#555",
+      },
+    },
+  };
+
   return (
     <div className="relative ">
-      <List
-        id="mainListModal"
-        dense
-        sx={{
-          width: "100%",
-          maxWidth: 360,
-          bgcolor: "background.paper",
-          height: 205,
-          overflowY: "scroll",
-        }}
-      >
+      <List id="mainListModal" dense sx={styles.list}>
         {[0, 1, 2, 3, 4, 5].map((value) => {
           const labelId = `checkbox-list-secondary-label-${value}`;
           return (

--- a/src/routes/LayOut/Header.tsx
+++ b/src/routes/LayOut/Header.tsx
@@ -31,7 +31,7 @@ export default function Header() {
           <img
             src={imgState}
             alt={"알람 아이콘"}
-            onClick={() => setImgState("/src/asset/images/bellalarm_icon.svg")}
+            onClick={() => setImgState("/src/asset/images/alarm_icon.svg")}
           />
         </Link>
 

--- a/src/routes/Main/LeftContents/ButtonListComponent/LinkButton.tsx
+++ b/src/routes/Main/LeftContents/ButtonListComponent/LinkButton.tsx
@@ -12,11 +12,11 @@ export default function LinkButton({ icon, title, onClick }: buttonProps) {
         size="sm" // 버튼 크기 설정
         variant="custom" // 사용자 정의 스타일
         textSize="sm" // 텍스트 크기
-        className="w-20 h-20 p-2 bg-[#7eacb5] rounded-[100px] flex flex-col gap-[6px] items-center justify-center mt-[30px] shadow-lg" // 추가적인 스타일
+        className="w-20 h-20 p-2 bg-[#7eacb5] rounded-[100px] flex flex-col gap-[4px] items-center justify-center mt-[30px] shadow-lg" // 추가적인 스타일
         onClick={onClick}
       >
         <img src={icon} alt={"게시판 버튼 로고"} />
-        <p className="text-[0.5rem] font-semibold text-white">{title}</p>
+        <p className="text-[0.75rem] font-semibold text-white">{title}</p>
       </Button>
     </>
   );

--- a/src/routes/Main/Main.tsx
+++ b/src/routes/Main/Main.tsx
@@ -32,7 +32,7 @@ export default function Main() {
     <section>
       <TopContents />
       {/* 컨텐츠 */}
-      <section className="mt-[60px] flex justify-between">
+      <section className="mt-[60px] flex justify-between pb-[100px]">
         {/* 좌측 컨텐츠 */}
         <LeftContents />
         {/* 중앙 컨텐츠 */}

--- a/src/routes/Main/RightComponent/FriendList.tsx
+++ b/src/routes/Main/RightComponent/FriendList.tsx
@@ -3,14 +3,13 @@ import CheckboxListSecondary from "../../../components/Mui/List";
 export default function FriendList() {
   return (
     <>
-      <article className="w-[22rem] shadow-lg border border-[#D6D6D6] rounded-[10px] mb-[24px]">
-        <article className="w-full h-12 bg-[#F6F6F6] rounded-t-[10px] border-b flex items-center px-[15px]">
-          <span className="text-lg font-bold">친구 목록</span>
+      <article className="w-[22rem] shadow-xl rounded-[10px] mb-[24px]">
+        <article className="w-full h-12 bg-[#F0F5F8] rounded-t-[10px] border-b flex items-center px-[15px]">
+          <p className="text-lg font-bold">친구 목록</p>
         </article>
         <article>
           <CheckboxListSecondary />
         </article>
-        <article className="w-full h-2 bg-[#F6F6F6] block rounded-b-[10px] border-t"></article>
       </article>
     </>
   );


### PR DESCRIPTION
## 🪄 변경 사항
- Fab.tsx에서 0 출력되는 콘솔 삭제
- Header.tsx 알람 이미지경로 수정
- etc폴더 삭제
- 메인페이지 버튼 텍스트 크기, 간격 조정
- 친구목록 스크롤바 디자인 변경(실선) + 상단 상자 색상 변경(#F0F5F8) + 하단 상자 제거
- calender 디자인 변경(색깔 넣고 그림자 처리 + 버튼 클릭 색상 변경(#F0F5F8))

## 💡 반영 브랜치
- feat/post-main-style

## 🖼️ 결과 화면 (생략 가능)
![image](https://github.com/user-attachments/assets/ec0c9df6-38c4-47cb-9d2f-d0c06517016c)

## 💬 리뷰어에게 전할 말
- ㅎ.ㅎb
