### PR TITLE
fix : editor - findDomNode에러 처리 ✔

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "quill": "^2.0.3",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
-    "react-quill": "^2.0.0",
+    "react-quill-new": "^3.3.3",
     "react-router-dom": "^6.28.0",
     "tailwind-merge": "^2.5.5",
     "tailwind-scrollbar-hide": "^1.1.7",

--- a/src/components/editor/BlogEditor.tsx
+++ b/src/components/editor/BlogEditor.tsx
@@ -1,8 +1,8 @@
-import { useEditorStore } from "../../store/store";
-import ReactQuill from "react-quill";
-import ConfirmDialog from "./ConfirmDialog";
-import "quill/dist/quill.snow.css";
+import ReactQuill from "react-quill-new";
+import "react-quill-new/dist/quill.snow.css";
 import "../../css/QuillCustom.css";
+import { useEditorStore } from "../../store/store";
+import ConfirmDialog from "./ConfirmDialog";
 
 export default function BlogEditor({
   onSave,
@@ -21,11 +21,11 @@ export default function BlogEditor({
   } = useEditorStore();
 
   const handleCancel = () => {
-    if (content.trim() || title.trim()) {
-      toggleDialog(true);
+    if ((content.trim() && content.trim() !== "<p><br></p>") || title.trim()) {
+      toggleDialog(true); // ConfirmDialog 열기
     } else {
       resetEditor();
-      toggleEditor();
+      toggleEditor(); // 내용이 없으면 바로 닫기
     }
   };
 
@@ -57,7 +57,6 @@ export default function BlogEditor({
     "underline",
     "color",
     "list",
-    "bullet",
     "link",
     "image",
   ];


### PR DESCRIPTION
## 🪄 변경 사항

프로젝트 실행마다 개발자 도구에 출력되는 findDomNode 에러 처리.
useRef이나 forwardRef으로는 해결이 불가능했음.
**react-quill-new로 재설치하면 호환성 문제 해결.**


## 💡 반영 브랜치

fix/editor

## 🖼️ 결과 화면 (생략 가능)

![image](https://github.com/user-attachments/assets/c4276cbc-34aa-4291-8825-00a1a83494ea)


## 💬 리뷰어에게 전할 말

pull 받으신 다음에,

**1. 기존 react-quill 제거**

pnpm remove react-quill

**2. react-quill-new 재설치**

pnpm install react-quill-new


경로설정이랑 코드 수정은 제가 해두었으니까 괜찮아욥.
참고로 리액트 19로 버전올려서 테스트해도 잘 됩니다.
혹시  개발자 도구에서 bullet 어쩌구~ 하는 에러 나오면 꼭 얘기해주세요.
터미널에서 나오는 source map 어쩌구~ 에러는 무시하셔도 됩니다.

