### PR TITLE
📝 feat/post-main 타이머 리셋버튼 개발 + 타이머 폰트 변경(LAB디지털), 메인페이지 높이값 screen으로 고정 

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -26,7 +26,7 @@ export default function App() {
   }, []);
   return (
     <Router>
-      <main className="px-[50px] mx-auto roboto-medium max-w-[1440px] select-none overflow-hidden">
+      <main className="px-[50px] mx-auto roboto-medium max-w-[1440px] h-screen select-none overflow-hidden">
         <Header />
         <Routes>
           <Route path="/login" element={<Login />} />{" "}

--- a/src/components/Mui/ResetFab.tsx
+++ b/src/components/Mui/ResetFab.tsx
@@ -1,0 +1,62 @@
+import { Box, Fab } from "@mui/material";
+import ReplayIcon from "@mui/icons-material/Replay";
+import { useTimerPlayStore, useTimerStore } from "../../store/store";
+
+export default function ResetFab() {
+  const isPlayBtnClicked = useTimerPlayStore((state) => state.isPlayBtnClicked);
+  const resetTimer = useTimerStore((state) => state.resetTimer);
+  const isResetAlertModalOn = useTimerStore(
+    (state) => state.isResetAlertModalOn
+  );
+  const setResetAlertModal = useTimerStore((state) => state.setResetAlertModal);
+
+  return (
+    <>
+      <Box
+        sx={{
+          "& > :not(style)": {
+            backgroundColor: "#F0F5F8",
+            zIndex: 0,
+          },
+        }}
+      >
+        <Fab
+          aria-label="play"
+          onClick={setResetAlertModal}
+          style={{
+            width: "3.5rem",
+            height: "3.5rem",
+            backgroundColor: isPlayBtnClicked ? "#778899" : "",
+            color: isPlayBtnClicked ? "#ffffff" : "",
+          }}
+        >
+          <ReplayIcon style={{ width: "2em", height: "2rem" }} />
+        </Fab>
+      </Box>
+      {isResetAlertModalOn ? (
+        <>
+          <article className="w-full h-full absolute top-0 left-0 z-50">
+            <article className="w-[400px] h-[200px] bg-white border rounded-[10px] flex flex-col gap-[20px] items-center justify-center absolute top-[50%] left-[50%] translate-x-[-50%] translate-y-[-50%] z-50">
+              <span className="text-[30px] font-bold">
+                정말 초기화 하시나요?
+              </span>
+              <button
+                onClick={() => {
+                  resetTimer();
+                  setResetAlertModal();
+                }}
+              >
+                네
+              </button>
+              <button onClick={setResetAlertModal}>아니요</button>
+            </article>
+            <article
+              className="w-full h-full bg-black bg-opacity-70 z-40"
+              onClick={setResetAlertModal}
+            ></article>
+          </article>
+        </>
+      ) : null}
+    </>
+  );
+}

--- a/src/components/howTime/HowTimeContents/HowTimeTimer.tsx
+++ b/src/components/howTime/HowTimeContents/HowTimeTimer.tsx
@@ -7,7 +7,12 @@ export default function HowTimeTimer({
 }) {
   return (
     <article className="w-full flex items-center justify-center mt-[30px] translate-y-[30px] opacity-0 animate-fadeIn_1s">
-      <Timer style={{}} changingHours={changingHours} isStaticTime={true} />
+      <Timer
+        style={{}}
+        changingHours={changingHours}
+        isStaticTime={true}
+        polygonForm="circle"
+      />
     </article>
   );
 }

--- a/src/css/font.css
+++ b/src/css/font.css
@@ -1,3 +1,15 @@
+@font-face {
+  font-family: "LAB";
+  src: url("https://cdn.jsdelivr.net/gh/projectnoonnu/noonfonts_20-07@1.0/LAB%EB%94%94%EC%A7%80%ED%84%B8.woff")
+    format("woff");
+  font-weight: normal;
+  font-style: normal;
+}
+
+.LAB-digital {
+  font-family: "LAB";
+}
+
 .roboto-medium {
   font-family: "Roboto", sans-serif;
 }

--- a/src/routes/Main/LeftContents/TimerComponent/Timer.tsx
+++ b/src/routes/Main/LeftContents/TimerComponent/Timer.tsx
@@ -9,6 +9,7 @@ interface TimerType {
   changingHours?: string;
   isStaticTime?: boolean;
   isFlowTime?: boolean;
+  polygonForm?: "square" | "circle";
 }
 
 export default function Timer({
@@ -16,6 +17,7 @@ export default function Timer({
   changingHours,
   isStaticTime = false,
   isFlowTime = false,
+  polygonForm = "square",
 }: TimerType) {
   const hours = useTimerStore((state) => state.hours);
   const minutes = useTimerStore((state) => state.minutes);
@@ -50,7 +52,7 @@ export default function Timer({
   return (
     <>
       <article
-        className={`timer-shadow flex flex-col gap-[10px] items-center justify-center w-[25rem] h-[25rem] rounded-full bg-[#F0F5F8] mb-5 transition-colors duration-200`}
+        className={`LAB-digital timer-shadow flex flex-col gap-[10px] items-center justify-center w-[25rem] h-[25rem] rounded-full bg-[#F0F5F8] mb-5 transition-colors duration-200`}
         style={style}
       >
         {isStaticTime ? (

--- a/src/routes/Main/LeftContents/TimerComponent/TimerComponent.tsx
+++ b/src/routes/Main/LeftContents/TimerComponent/TimerComponent.tsx
@@ -1,4 +1,5 @@
 import FloatingActionButtons from "../../../../components/Mui/Fab";
+import ResetFab from "../../../../components/Mui/ResetFab";
 import { useTimerPlayStore, useTimerStore } from "../../../../store/store";
 import Timer from "./Timer";
 
@@ -16,7 +17,10 @@ export default function TimerComponent() {
         }}
         isFlowTime={true}
       />
-      <FloatingActionButtons />
+      <article className="flex gap-[10px]">
+        <FloatingActionButtons />
+        <ResetFab />
+      </article>
     </>
   );
 }

--- a/src/store/store.ts
+++ b/src/store/store.ts
@@ -135,6 +135,9 @@ interface TimerStorage {
   isTimerActive: boolean;
   toggleTimer: () => void;
   activeTimer: () => void;
+  resetTimer: () => void;
+  isResetAlertModalOn: boolean;
+  setResetAlertModal: () => void;
   isAchieve: boolean;
   setIsAchieve: () => void;
 }
@@ -176,11 +179,22 @@ export const useTimerStore = create<TimerStorage>((set) => ({
       };
     });
   },
+  resetTimer: () => {
+    set(() => ({
+      hours: 0,
+      minutes: 0,
+      seconds: 0,
+    }));
+  },
+  isResetAlertModalOn: false,
+  setResetAlertModal: () => {
+    set((state) => ({ isResetAlertModalOn: !state.isResetAlertModalOn }));
+  },
   isAchieve: false,
   setIsAchieve: () => set((state) => ({ isAchieve: !state.isAchieve })),
 }));
 
-// 메인페이지 TimeSetter 저장소
+// 메인페이지 TimeSetter 저장소(static 시간 관리)
 interface TimeSetterStorage {
   isTimeSetterOpen: boolean;
   setIsTimeSetterOpen: () => void;


### PR DESCRIPTION
## 🪄 변경 사항
- 타이머 리셋 버튼 추가 + 기능구현
- 메인페이지 높이값 screen으로 고정(overflow때문에)
- 타이머 폰트 교체(LAB디지털 폰트)
- 타이머 모양 변경 밑작업(컴포넌트에 square, circle 선택할 수 있게 미리 작업해놨습니다. polygonForm)

## 💡 반영 브랜치
feat/post-main

## 🖼️ 결과 화면 (생략 가능)
![image](https://github.com/user-attachments/assets/2ffe3b28-9425-4968-a974-2c75cc6e4c85)
![image](https://github.com/user-attachments/assets/8da14173-8afd-4d5a-9d92-ba1008d12de8)

## 💬 리뷰어에게 전할 말
- 디자인 짜봐야 하는데 부탁드립니다 디자인 박사님들 ^^7 특히 승연님 ^.^b 제일 감각적이셔
