### PR TITLE
📝 feat/post-main-style : 달력 포커스 스타일 오류 수정 + ToDo세부수정(버튼추가, 체크상태저장)

### DIFF
--- a/src/components/Mui/Calender.tsx
+++ b/src/components/Mui/Calender.tsx
@@ -12,6 +12,9 @@ export default function BasicDateCalendar() {
       "& .MuiButtonBase-root.Mui-selected": {
         backgroundColor: "#7EACB5",
       },
+      "& .MuiButtonBase-root:focused": {
+        backgroundColor: "#7EACB5",
+      },
       "& .MuiPickersDay-today": {},
     },
   };

--- a/src/routes/Main/CenterContents/Calender/ToDo.tsx
+++ b/src/routes/Main/CenterContents/Calender/ToDo.tsx
@@ -20,36 +20,42 @@ export default function ToDo() {
             <Pin key={i} />
           ))}
         </article>
-        <article className="w-full h-[500px] bg-white overflow-y-scroll">
+        <article className="w-full h-[520px] bg-white overflow-y-scroll">
           <ul>
             {localStorage.getItem("ToDoList")
               ? ToDoList.map((ToDo, i) => (
                   <ToDoListItem
                     key={ToDo.id}
+                    findid={ToDo.id}
                     text={ToDo.text}
+                    ckeck={ToDo.checked}
                     color={"#666666"}
                     index={i}
                   />
                 ))
               : null}
             {isShowEditor ? <ToDoEditor /> : null}
-            <li className="w-full h-[50px] border-b border-[#D0E5F9] hover:bg-[#e9e9e9]">
-              <Button
-                size="lg" // 버튼 크기
-                variant="todo" // 사용자 정의 스타일
-                textSize="sm" // 텍스트 크기
-                className="flex items-center gap-[20px] w-full h-full pr-[12px] justify-start pl-6 hover:bg-[#e9e9e9]"
-                onClick={() => {
-                  toggleShowEditor();
-                }}
-              >
-                <img
-                  src={"/src/asset/images/small_icon.svg"}
-                  alt={"추가 아이콘"}
-                />
-                <span className="text-[#666666] font-medium ">할 일 추가</span>
-              </Button>
-            </li>
+            {!isShowEditor ? (
+              <li className="w-full h-[50px] border-b border-[#D0E5F9] hover:bg-[#e9e9e9]">
+                <Button
+                  size="lg" // 버튼 크기
+                  variant="todo" // 사용자 정의 스타일
+                  textSize="sm" // 텍스트 크기
+                  className="flex items-center gap-[20px] w-full h-full pr-[12px] justify-start pl-6 hover:bg-[#e9e9e9]"
+                  onClick={() => {
+                    toggleShowEditor();
+                  }}
+                >
+                  <img
+                    src={"/src/asset/images/small_icon.svg"}
+                    alt={"추가 아이콘"}
+                  />
+                  <span className="text-[#666666] font-medium ">
+                    할 일 추가
+                  </span>
+                </Button>
+              </li>
+            ) : null}
           </ul>
         </article>
         <article className="w-full h-[30px] bg-white rounded-b-2xl"></article>

--- a/src/routes/Main/CenterContents/Calender/ToDoEditor.tsx
+++ b/src/routes/Main/CenterContents/Calender/ToDoEditor.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useRef } from "react";
 import { useToDoStore } from "../../../../store/store";
 import { v4 as uuidv4 } from "uuid";
+import Button from "../../../../components/common/Button";
 
 export default function ToDoEditor() {
   const editorInputRef = useRef<HTMLInputElement>(null);
@@ -17,9 +18,9 @@ export default function ToDoEditor() {
     }
   }, [isShowEditor]);
   return (
-    <li className="w-full h-[50px] border-b flex gap-[18px] border-[#D0E5F9]">
+    <li className="w-full h-[50px] border-b flex border-[#D0E5F9]">
       <input
-        placeholder="console.log(                                                                );"
+        placeholder="console.log(                                                   );"
         type="text"
         ref={editorInputRef}
         onChange={(event) => {
@@ -32,13 +33,36 @@ export default function ToDoEditor() {
             toggleShowEditor();
             localStorage.setItem(
               "ToDoList",
-              JSON.stringify([...ToDoList, { text: EditorText, id: uuidv4() }])
+              JSON.stringify([
+                ...ToDoList,
+                { text: EditorText, id: uuidv4(), checked: false },
+              ])
             );
           }
         }}
         value={EditorText}
         className="w-full h-full p-5 outline-none"
       />
+      <Button
+        size="lg" // 버튼 크기
+        variant="todo" // 사용자 정의 스타일
+        textSize="sm" // 텍스트 크기
+        className="flex items-center justify-center gap-[20px] w-[60px] h-full rounded-full hover:bg-[#e9e9e9]"
+        onClick={() => {
+          if (EditorText === "") return toggleShowEditor();
+          updateToDoList();
+          toggleShowEditor();
+          localStorage.setItem(
+            "ToDoList",
+            JSON.stringify([
+              ...ToDoList,
+              { text: EditorText, id: uuidv4(), checked: false },
+            ])
+          );
+        }}
+      >
+        <img src={"/src/asset/images/small_icon.svg"} alt={"추가 아이콘"} />
+      </Button>
     </li>
   );
 }

--- a/src/routes/Main/CenterContents/Calender/ToDoListItem.tsx
+++ b/src/routes/Main/CenterContents/Calender/ToDoListItem.tsx
@@ -3,18 +3,23 @@ import { useToDoStore } from "../../../../store/store";
 import { DeleteOutline, DeleteRounded } from "@mui/icons-material";
 
 export default function ToDoListItem({
+  findid,
   color,
   text,
   index,
+  ckeck,
 }: {
+  findid: string;
   color?: string;
   text: string;
   index: number;
+  ckeck: boolean;
 }) {
-  const buttonRef = useRef<HTMLInputElement>(null);
-  const [btnChecked, setBtnChecked] = useState<boolean>(false);
   const deleteToDoList = useToDoStore((state) => state.deleteToDoList);
   const ToDoList = useToDoStore((state) => state.ToDoList);
+  const updateToDoListCheck = useToDoStore(
+    (state) => state.updateToDoListCheck
+  );
   const clickedIndex = useToDoStore((state) => state.clickedIndex);
   const [isDeleteIconHovered, setIsDeleteIconHovered] = useState(false);
 
@@ -23,19 +28,27 @@ export default function ToDoListItem({
       <article className="self-center flex gap-[18px]">
         <input
           type="checkbox"
-          ref={buttonRef}
           className={"w-[20px] h-[20px]"}
+          checked={ckeck}
           onChange={() => {
-            setBtnChecked(() => !btnChecked);
+            // 체크시 로컬저장소랑 전역변수 체크상태 업데이트
+            const newToDoList = ToDoList.map((e) => {
+              if (e.id === findid) {
+                return { text: e.text, id: e.id, checked: !e.checked };
+              }
+              return e;
+            });
+            updateToDoListCheck(newToDoList);
+            localStorage.setItem("ToDoList", JSON.stringify(newToDoList));
           }}
         />
         <span
           className={`font-medium`}
-          style={{ color: `${btnChecked ? color : ""}` }}
+          style={{ color: `${ckeck ? color : ""}` }}
         >
           {text}
         </span>
-        {btnChecked ? (
+        {ckeck ? (
           <article className="w-[80%] absolute left-[40px] self-center">
             <img src="/src/asset/images/line_through.svg" alt="빨간줄" />
           </article>

--- a/src/routes/Main/CenterContents/Calender/ToDoListItem.tsx
+++ b/src/routes/Main/CenterContents/Calender/ToDoListItem.tsx
@@ -33,11 +33,13 @@ export default function ToDoListItem({
           onChange={() => {
             // 체크시 로컬저장소랑 전역변수 체크상태 업데이트
             const newToDoList = ToDoList.map((e) => {
+              // 리스트의 uuid와 일치하는 요소를 찾아 checked상태를 변경
               if (e.id === findid) {
                 return { text: e.text, id: e.id, checked: !e.checked };
               }
               return e;
             });
+            // 전역변수, 로컬저장소에 변경내용 저장
             updateToDoListCheck(newToDoList);
             localStorage.setItem("ToDoList", JSON.stringify(newToDoList));
           }}

--- a/src/routes/Main/LeftContents/TimerComponent/Timer.tsx
+++ b/src/routes/Main/LeftContents/TimerComponent/Timer.tsx
@@ -52,7 +52,9 @@ export default function Timer({
   return (
     <>
       <article
-        className={`LAB-digital timer-shadow flex flex-col gap-[10px] items-center justify-center w-[25rem] h-[25rem] rounded-full bg-[#F0F5F8] mb-5 transition-colors duration-200`}
+        className={`LAB-digital timer-shadow flex flex-col gap-[10px] items-center justify-center w-[25rem] h-[25rem] bg-[#F0F5F8] mb-5 transition-colors duration-200 ${
+          polygonForm === "circle" ? "rounded-full" : "rounded-[10px]"
+        }`}
         style={style}
       >
         {isStaticTime ? (

--- a/src/store/store.ts
+++ b/src/store/store.ts
@@ -62,13 +62,15 @@ export const useTimerPlayStore = create<TimerPlayStoreState>((set) => ({
 
 // 메인페이지 Todo 리스트 저장소
 interface ToDoType {
-  ToDoList: { text: string; id: string }[];
+  ToDoList: { text: string; id: string; checked: boolean }[];
   isShowEditor: boolean;
   EditorText: string;
-  Checked: boolean;
   clickedIndex: number;
   toggleShowEditor: () => void;
   updateEditorText: (event: React.ChangeEvent<HTMLInputElement>) => void;
+  updateToDoListCheck: (
+    newToDoList: { text: string; id: string; checked: boolean }[]
+  ) => void;
   updateToDoList: () => void;
   deleteToDoList: (index: number) => void;
   setClickedIndex: (index: number) => void;
@@ -77,7 +79,6 @@ export const useToDoStore = create<ToDoType>((set) => ({
   ToDoList: JSON.parse(localStorage.getItem("ToDoList")!) || [],
   isShowEditor: false,
   EditorText: "",
-  Checked: false,
   clickedIndex: -1,
   toggleShowEditor: () =>
     set((state) => ({
@@ -89,9 +90,20 @@ export const useToDoStore = create<ToDoType>((set) => ({
       EditorText: event.target.value,
     }));
   },
+  // 체크박스 클릭시 체크상태 업데이트
+  updateToDoListCheck: (newToDoList) => {
+    console.log(newToDoList);
+    set(() => ({
+      ToDoList: newToDoList,
+    }));
+  },
+  // todo리스트 최초생성시 Todo리스트 배열에 추가
   updateToDoList: () => {
     set((state) => ({
-      ToDoList: [...state.ToDoList, { text: state.EditorText, id: uuidv4() }],
+      ToDoList: [
+        ...state.ToDoList,
+        { text: state.EditorText, id: uuidv4(), checked: false },
+      ],
       EditorText: "",
     }));
   },


### PR DESCRIPTION
## 🪄 변경 사항
- 달력 날짜 focus 시 색깔 파란색인 현상 수정
- 시계 형태 네모, 동그라미 선택 가능
- todo리스트 할 일 추가시 할 일 추가 버튼은 사라지고 input창만 남게 만듬
- 할 일 추가 모바일용 추가 버튼 생성
- todo리스트 체크상태 useState => 로컬 + store에 저장하도록 변경해서 창 새로고침 or 껏다 다시 켜도 초기화 되지 않음(local에 저장된 상태로 불러옴)

## 💡 반영 브랜치
- feat/post-main-style

## 🖼️ 결과 화면 (생략 가능)
![image](https://github.com/user-attachments/assets/26adf793-fa8c-419a-ad38-842aba162efa)

## 💬 리뷰어에게 전할 말
- 점점 코드가 복잡해지고 있어요🥲
