### PR TITLE
📝 Feat/post main develop : 타이머 목표달성 알람음 활성/비활성 추가 + 타이머 목표 초기화시에도 다시 모달창 등장하게 수정

### DIFF
--- a/src/routes/Main/LeftContents/TimerComponent/Timer.tsx
+++ b/src/routes/Main/LeftContents/TimerComponent/Timer.tsx
@@ -10,6 +10,7 @@ interface TimerType {
   isStaticTime?: boolean;
   isFlowTime?: boolean;
   polygonForm?: "square" | "circle";
+  alertSound?: boolean;
 }
 
 export default function Timer({
@@ -18,6 +19,7 @@ export default function Timer({
   isStaticTime = false,
   isFlowTime = false,
   polygonForm = "square",
+  alertSound = false,
 }: TimerType) {
   const hours = useTimerStore((state) => state.hours);
   const minutes = useTimerStore((state) => state.minutes);
@@ -28,6 +30,7 @@ export default function Timer({
   const isAchieve = useTimerStore((state) => state.isAchieve);
   const setIsAchieve = useTimerStore((state) => state.setIsAchieve);
 
+  // 시간 달성 체크 기능
   useEffect(() => {
     const checkAchievement = () => {
       if (Number(staticHours) < hours) {
@@ -50,16 +53,17 @@ export default function Timer({
         isAchieve && setIsAchieve();
       }
     };
-
     checkAchievement();
   }, [seconds]);
 
   useEffect(() => {
     if (isAchieve) {
-      const audio = new Audio("/src/asset/achieved_alarm.mp3");
-      audio.play().catch((error) => {
-        console.error("❌ 알람 소리가 재생되지 않았습니다.", error);
-      });
+      if (alertSound) {
+        const audio = new Audio("/src/asset/achieved_alarm.mp3");
+        audio.play().catch((error) => {
+          console.error("❌ 알람 소리가 재생되지 않았습니다.", error);
+        });
+      }
     }
   }, [isAchieve]);
   return (

--- a/src/routes/Main/LeftContents/TimerComponent/Timer.tsx
+++ b/src/routes/Main/LeftContents/TimerComponent/Timer.tsx
@@ -29,6 +29,10 @@ export default function Timer({
   const staticSeconds = useTimerStore((state) => state.staticSeconds);
   const isAchieve = useTimerStore((state) => state.isAchieve);
   const setIsAchieve = useTimerStore((state) => state.setIsAchieve);
+  const trophyModalViewed = useTimerStore((state) => state.trophyModalViewed);
+  const setTrophyModalNotViewed = useTimerStore(
+    (state) => state.setTrophyModalNotViewed
+  );
 
   // 시간 달성 체크 기능
   useEffect(() => {
@@ -63,6 +67,11 @@ export default function Timer({
         audio.play().catch((error) => {
           console.error("❌ 알람 소리가 재생되지 않았습니다.", error);
         });
+      }
+    }
+    if (!isAchieve) {
+      if (trophyModalViewed === true) {
+        setTrophyModalNotViewed();
       }
     }
   }, [isAchieve]);

--- a/src/routes/Main/LeftContents/TimerComponent/TimerComponent.tsx
+++ b/src/routes/Main/LeftContents/TimerComponent/TimerComponent.tsx
@@ -16,6 +16,7 @@ export default function TimerComponent() {
           color: `${isPlayBtnClicked ? "#ffffff" : ""}`,
         }}
         isFlowTime={true}
+        alertSound={true}
       />
       <article className="flex gap-[10px]">
         <FloatingActionButtons />

--- a/src/store/store.ts
+++ b/src/store/store.ts
@@ -167,6 +167,7 @@ interface TimerStorage {
   setIsAchieve: () => void;
   trophyModalViewed: boolean;
   setTrophyModalViewed: () => void;
+  setTrophyModalNotViewed: () => void;
 }
 export const useTimerStore = create<TimerStorage>((set) => ({
   hours: localStorage.getItem("TimerTime")
@@ -222,6 +223,7 @@ export const useTimerStore = create<TimerStorage>((set) => ({
   // 트로피 모달 전역변수입니당
   trophyModalViewed: false,
   setTrophyModalViewed: () => set(() => ({ trophyModalViewed: true })),
+  setTrophyModalNotViewed: () => set(() => ({ trophyModalViewed: false })),
 }));
 
 // 메인페이지 TimeSetter 저장소(static 시간 관리)


### PR DESCRIPTION
## 🪄 변경 사항
- Timer 컴포넌트 목표달성 알람음 활성/비활성 추가(alertSound, 기본값 false)
- 타이머 목표 달성 초기화 하고 다시 목표 달성시에도 트로피 모달이 다시 등장하게 수정(setTrophyModalNotViewed 함수 store에 추가)

## 💡 반영 브랜치
-  Feat/post main develop

## 🖼️ 결과 화면 (생략 가능)

## 💬 리뷰어에게 전할 말
- 구우웃👍
