### PR TITLE
📝 feat/post-main : 로그인시 목표달성 알람음 재생되던 현상 수정(alertSoundPlayed 트리거 추가)

### DIFF
--- a/src/routes/Main/LeftContents/TimerComponent/Timer.tsx
+++ b/src/routes/Main/LeftContents/TimerComponent/Timer.tsx
@@ -33,6 +33,13 @@ export default function Timer({
   const setTrophyModalNotViewed = useTimerStore(
     (state) => state.setTrophyModalNotViewed
   );
+  const alertSoundPlayed = useTimerStore((state) => state.alertSoundPlayed);
+  const setAlertSoundPlayed = useTimerStore(
+    (state) => state.setAlertSoundPlayed
+  );
+  const setAlertSoundNotPlayed = useTimerStore(
+    (state) => state.setAlertSoundNotPlayed
+  );
 
   // 시간 달성 체크 기능
   useEffect(() => {
@@ -61,17 +68,23 @@ export default function Timer({
   }, [seconds]);
 
   useEffect(() => {
-    if (isAchieve) {
+    if (isAchieve && !alertSoundPlayed) {
       if (alertSound) {
         const audio = new Audio("/src/asset/achieved_alarm.mp3");
-        audio.play().catch((error) => {
-          console.error("❌ 알람 소리가 재생되지 않았습니다.", error);
-        });
+        audio
+          .play()
+          .then(() => {
+            setAlertSoundPlayed();
+          })
+          .catch((error) => {
+            console.error("❌ 알람 소리가 재생되지 않았습니다.", error);
+          });
       }
     }
     if (!isAchieve) {
       if (trophyModalViewed === true) {
         setTrophyModalNotViewed();
+        setAlertSoundNotPlayed();
       }
     }
   }, [isAchieve]);

--- a/src/store/store.ts
+++ b/src/store/store.ts
@@ -168,6 +168,9 @@ interface TimerStorage {
   trophyModalViewed: boolean;
   setTrophyModalViewed: () => void;
   setTrophyModalNotViewed: () => void;
+  alertSoundPlayed: boolean;
+  setAlertSoundPlayed: () => void;
+  setAlertSoundNotPlayed: () => void;
 }
 export const useTimerStore = create<TimerStorage>((set) => ({
   hours: localStorage.getItem("TimerTime")
@@ -224,6 +227,9 @@ export const useTimerStore = create<TimerStorage>((set) => ({
   trophyModalViewed: false,
   setTrophyModalViewed: () => set(() => ({ trophyModalViewed: true })),
   setTrophyModalNotViewed: () => set(() => ({ trophyModalViewed: false })),
+  alertSoundPlayed: false,
+  setAlertSoundPlayed: () => set(() => ({ alertSoundPlayed: true })),
+  setAlertSoundNotPlayed: () => set(() => ({ alertSoundPlayed: false })),
 }));
 
 // 메인페이지 TimeSetter 저장소(static 시간 관리)


### PR DESCRIPTION
## 🪄 변경 사항
- 로그인시 목표달성 알람음 재생되던 현상 수정했습니다.
- alertSoundPlayed 전역변수를 만들고 true false 핸들러도 추가로 만들어 알람이 한 번 울리면 목표달성(achieve)가 false로 변경되지 않는 이상 다시 재생되지 않게 했습니다.

## 💡 반영 브랜치
- feat/post-main

## 🖼️ 결과 화면 (생략 가능)

## 💬 리뷰어에게 전할 말
- 또로롱🎵