### PR TITLE
📝 Feat/post login: 로그인시 유저데이터 API.ts store에 저장(API.ts), 로그아웃 클릭시 로그아웃 post 요청(제대로 가는건진 모르겠음)

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -8,9 +8,9 @@ import Join from "./routes/Join/Join";
 import Noti from "./components/notifications/Noti";
 import JoinSuccess from "./routes/Join/JoinSuccess";
 import ErrorPage from "./components/404Page/ErrorPage";
+import { useLoginStore } from "./store/API";
 
 export default function App() {
-  //
   useEffect(() => {
     if (!localStorage.getItem("ToDoList")) {
       localStorage.setItem("ToDoList", "[]");

--- a/src/components/Modal/ProfileModal.tsx
+++ b/src/components/Modal/ProfileModal.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useRef } from "react";
 import { Link } from "react-router-dom";
 import { useprofileModalStore } from "../../store/store";
+import { axiosInstance } from "../../api/axios";
 
 export default function Modal({
   y,
@@ -16,6 +17,10 @@ export default function Modal({
   const close = useprofileModalStore((s) => s.close);
   const animating = useprofileModalStore((s) => s.animating);
   const contentRef = useRef<HTMLDivElement>(null);
+
+  const logOut = async () => {
+    await axiosInstance.post(`/logout`).then((res) => console.log(res.status));
+  };
 
   useEffect(() => {
     const onClick = (e: MouseEvent) => {
@@ -114,7 +119,10 @@ export default function Modal({
                   <Link
                     to="./login"
                     className="text-black text-lg font-medium font-['Inter']"
-                    onClick={close}
+                    onClick={() => {
+                      close();
+                      logOut();
+                    }}
                   >
                     로그아웃
                   </Link>

--- a/src/routes/Join/Join.tsx
+++ b/src/routes/Join/Join.tsx
@@ -5,6 +5,7 @@ import { useNavigate } from "react-router-dom";
 import { Alert } from "@mui/material";
 import SubmitButton from "../../components/Form/SubmitButton";
 import { axiosInstance } from "../../api/axios";
+import { useLoginStore } from "../../store/API";
 
 export default function Join() {
   const [email, setEmail] = useState("");
@@ -93,6 +94,7 @@ export default function Join() {
   };
 
   // 폼 제출 처리
+
   const handleSubmit = async (e: React.FormEvent<HTMLButtonElement>) => {
     e.preventDefault();
     if (!email || !password || !checkPassword || !userName) {

--- a/src/routes/Login/Login.tsx
+++ b/src/routes/Login/Login.tsx
@@ -5,6 +5,7 @@ import FormContainer from "../../components/Form/FormContainer";
 import Input from "../../components/Form/Input";
 import SubmitButton from "../../components/Form/SubmitButton";
 import { axiosInstance } from "../../api/axios";
+import { useLoginStore } from "../../store/API";
 
 export default function Login() {
   const login = "로그인";
@@ -39,6 +40,8 @@ export default function Login() {
 
   const navigate = useNavigate();
 
+  const setUser = useLoginStore((state) => state.setUser);
+
   const handleSubmit = async (e: React.FormEvent<HTMLButtonElement>) => {
     e.preventDefault();
     if (!email || !password) {
@@ -52,10 +55,15 @@ export default function Login() {
     }
 
     try {
-      await axiosInstance.post("/login", {
-        email,
-        password,
-      });
+      await axiosInstance
+        .post("/login", {
+          email,
+          password,
+        })
+        .then((res) => {
+          console.log(res.data.token);
+          setUser(res.data.user);
+        });
       navigate("/"); // 성공 시 이동
     } catch (error) {
       setLoginError(true); // 에러 상태 설정

--- a/src/routes/Main/Main.tsx
+++ b/src/routes/Main/Main.tsx
@@ -12,6 +12,9 @@ import TopContents from "./TopContents/TopContents";
 import { Favorite } from "@mui/icons-material";
 import { styled } from "@mui/material";
 import FriendManageModal from "../../components/Modal/FriendManageModal";
+import { axiosInstance } from "../../api/axios";
+import { useEffect } from "react";
+import { useLoginStore } from "../../store/API";
 
 const HeartStyle = styled("div")`
   @keyframes float {
@@ -40,6 +43,12 @@ export default function Main() {
   );
   const modal = useFriendModalStore((s) => s.modal);
 
+  // user 정보 가져오기
+  const user = useLoginStore((state) => state.user);
+  useEffect(() => {
+    console.log(user);
+  });
+
   return (
     <section>
       <TopContents />
@@ -60,6 +69,14 @@ export default function Main() {
           <Favorite />
         </HeartStyle>
       ))}
+      {/* 임시 로그아웃 기능 */}
+      {/* <button
+        onClick={() => {
+          axiosInstance.post(`/logout`).then((res) => console.log(res));
+        }}
+      >
+        로그아웃
+      </button> */}
       {/* 트로피 모달 프로토타입입니당 */}
       {isAchieve && !trophyModalViewed ? (
         <article className="animate-show w-screen h-screen absolute top-0 left-0 z-50 overflow-hidden">

--- a/src/store/API.ts
+++ b/src/store/API.ts
@@ -1,0 +1,11 @@
+import { create } from "zustand";
+
+// 로그인시 가져오는 유저정보
+interface LoginType {
+  user: userType | {};
+  setUser: (axiosData: userType) => void;
+}
+export const useLoginStore = create<LoginType>((set) => ({
+  user: {},
+  setUser: (axiosData) => set(() => ({ user: axiosData })),
+}));

--- a/src/store/store.ts
+++ b/src/store/store.ts
@@ -172,6 +172,9 @@ interface TimerStorage {
   trophyModalViewed: boolean;
   setTrophyModalViewed: () => void;
   setTrophyModalNotViewed: () => void;
+  alertSoundPlayed: boolean;
+  setAlertSoundPlayed: () => void;
+  setAlertSoundNotPlayed: () => void;
   isPlayingWhiteNoise: boolean;
   toggleWhiteNoise: () => void;
 }
@@ -230,6 +233,9 @@ export const useTimerStore = create<TimerStorage>((set) => ({
   trophyModalViewed: false,
   setTrophyModalViewed: () => set(() => ({ trophyModalViewed: true })),
   setTrophyModalNotViewed: () => set(() => ({ trophyModalViewed: false })),
+  alertSoundPlayed: false,
+  setAlertSoundPlayed: () => set(() => ({ alertSoundPlayed: true })),
+  setAlertSoundNotPlayed: () => set(() => ({ alertSoundPlayed: false })),
 
   //백색소음 재생
   isPlayingWhiteNoise: false,


### PR DESCRIPTION
## 🪄 변경 사항
-  로그인시 유저데이터 API.ts store에 저장(API.ts) - 그런데 데이터가 새로고침시에 기본 설정값 {}으로 돌아감
- 로그아웃 클릭시 로그아웃 post 요청(제대로 가는건진 모르겠음)

## 💡 반영 브랜치
-  Feat/post-login

## 🖼️ 결과 화면 (생략 가능)
![image](https://github.com/user-attachments/assets/3a32c8fb-6eb2-421a-9f18-c6a0c7f5cfd9)
- 받아온 전역변수를 콘솔출력 했습니다, 토큰이랑(Main.tsx에 콘솔출력함)

## 💬 리뷰어에게 전할 말
- 잘자요😇