### PR TITLE
feat: Community route, 타유저 프로필 페이지 Link 추가 

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -10,6 +10,7 @@ import ErrorPage from "./components/404Page/ErrorPage";
 import UserPage from "./routes/UserPage/UserPage";
 import Mypage from "./routes/Mypage/Mypage";
 import LayOut from "./routes/LayOut/LayOut";
+import Community from "./routes/Community/Community";
 
 export default function App() {
   useEffect(() => {
@@ -37,6 +38,7 @@ export default function App() {
           <Route path="/mypage" element={<Mypage />} />
           <Route path="/userpage/:username" element={<UserPage />} />
           <Route path="/notifications" element={<Noti />} />
+          <Route path="/community" element={<Community />} />
           <Route path="*" element={<ErrorPage />} />
         </Route>
       </Routes>

--- a/src/components/Modal/ProfileModal.tsx
+++ b/src/components/Modal/ProfileModal.tsx
@@ -9,6 +9,9 @@ export default function Modal({ y, x }: { x?: number; y?: number }) {
   const close = useprofileModalStore((s) => s.close);
   const contentRef = useRef<HTMLDivElement>(null);
 
+  //임시 username
+  const username = "testuser";
+
   const logOut = async () => {
     await axiosInstance.post(`/logout`).then((res) => console.log(res.status));
   };
@@ -83,7 +86,7 @@ export default function Modal({ y, x }: { x?: number; y?: number }) {
                 </div>
                 {type === "header" ? (
                   <Link
-                    to="./mypage"
+                    to="/mypage"
                     className="text-black text-lg font-medium font-['Inter']"
                     onClick={close}
                   >
@@ -91,7 +94,7 @@ export default function Modal({ y, x }: { x?: number; y?: number }) {
                   </Link>
                 ) : (
                   <Link
-                    to=""
+                    to={`./userpage/${username}`}
                     className="text-black text-lg font-medium font-['Inter']"
                     onClick={close}
                   >
@@ -114,7 +117,7 @@ export default function Modal({ y, x }: { x?: number; y?: number }) {
                     />
                   </div>
                   <Link
-                    to="./login"
+                    to="/login"
                     className="text-black text-lg font-medium font-['Inter']"
                     onClick={() => {
                       close();

--- a/src/routes/Community/Community.tsx
+++ b/src/routes/Community/Community.tsx
@@ -1,0 +1,5 @@
+import React from "react";
+
+export default function Community() {
+  return <div>Community</div>;
+}

--- a/src/routes/LayOut/Header.tsx
+++ b/src/routes/LayOut/Header.tsx
@@ -1,4 +1,4 @@
-import { Link } from "react-router";
+import { Link, useLocation } from "react-router";
 import Modal from "../../components/Modal/ProfileModal";
 import { useState } from "react";
 import { useprofileModalStore } from "../../store/store";
@@ -16,21 +16,30 @@ export default function Header() {
     console.log(useprofileModalStore.getState());
   };
   const [imgState, setImgState] = useState("/src/asset/images/bell.svg");
+  const location = useLocation();
 
   return (
     <header className="w-full h-[80px] fixed justify-between flex top-0 left-0 items-center px-[50px] bg-white z-40">
       <article className="flex items-center gap-[30px]">
-        <Link to="#">
+        <Link to="/">
           <img
             src={"/src/asset/images/runtime_logo.svg"}
             alt={"런타임 로고"}
             className="w-[40px] h-[40px] object-cover"
           />
         </Link>
-        <Link to="/" className="text-lg">
+        <Link
+          to="/"
+          className={`text-lg ${location.pathname === "/" ? "font-bold" : ""}`}
+        >
           홈
         </Link>
-        <Link to="/community" className="text-lg">
+        <Link
+          to="/community"
+          className={`text-lg ${
+            location.pathname === "/community" ? "font-bold" : ""
+          }`}
+        >
           게시글
         </Link>
       </article>

--- a/src/routes/LayOut/Header.tsx
+++ b/src/routes/LayOut/Header.tsx
@@ -30,7 +30,7 @@ export default function Header() {
         <Link to="/" className="text-lg">
           홈
         </Link>
-        <Link to="#" className="text-lg">
+        <Link to="/community" className="text-lg">
           게시글
         </Link>
       </article>

--- a/src/routes/Main/Main.tsx
+++ b/src/routes/Main/Main.tsx
@@ -79,12 +79,12 @@ export default function Main() {
       </button> */}
       {/* 트로피 모달 프로토타입입니당 */}
       {isAchieve && !trophyModalViewed ? (
-        <article className="animate-show w-screen h-screen absolute top-0 left-0 z-50 overflow-hidden">
-          <article className="animate-spaceInDown_1s absolute top-[50%] left-[50%] opacity-0 w-[500px] h-[500px block">
+        <article className="absolute top-0 left-0 z-50 w-screen h-screen overflow-hidden animate-show">
+          <article className="animate-spaceInDown_1s absolute top-[50%] left-[50%] opacity-0 w-[500px] h-[500px] block">
             <img src="./src/asset/images/trophy.svg" alt="트로피 이미지" />
           </article>
           <article className="absolute bottom-[10%] left-[50%] translate-x-[-50%] translate-y-[-50%]">
-            <h2 className="text-white text-4xl font-bold">
+            <h2 className="text-4xl font-bold text-white">
               오늘의 목표시간을 달성했어요!
             </h2>
             <article>


### PR DESCRIPTION
## 🪄 변경 사항
- 타유저 프로필 보기 버튼을 누르면 프로필 페이지로 이동하도록 Link 추가
- 트로피 모달 오타 수정 h-[500px]
- Community route 추가 
- 경로가 '/'일 경우 '홈' 링크를 볼드 처리
- 경로가 '/community'일 경우 '게시글' 링크를 볼드 처리


## 💡 반영 브랜치
- feat/user-profile-route ➡️ main

## 🖼️ 결과 화면 (생략 가능)
<img width="951" alt="image" src="https://github.com/user-attachments/assets/30c9dc19-1cdc-40d1-a0f2-d85892b49727" />


## 💬 리뷰어에게 전할 말
- Community route 때문에 이따 conflict 날 수도 있을 것 같습니다 🥲