### PR TITLE
✨ feat: 마이페이지 API 연결 및 프로필 편집 시 데이터 저장 기능 구현

### DIFF
--- a/src/api/api.d.ts
+++ b/src/api/api.d.ts
@@ -16,4 +16,9 @@ interface userType {
   createdAt: string;
   updatedAt: string;
   __v: number;
+  isCover?: {
+    website: string;
+    field: string;
+  };
+  username?: string;
 }

--- a/src/store/store.ts
+++ b/src/store/store.ts
@@ -356,12 +356,8 @@ export const useProfileStore = create<ProfileState>((set, get) => ({
   setTempProfilePic: (pic) => set({ tempProfilePic: pic }),
   setFullName: (fullName) => {
     set({ fullName });
-    const { username } = get();
-    //username이 미정이면 fullName 할당
-    if (!username.trim()) {
-      set({ username: fullName });
-    }
   },
+
   setUsername: (username) => set({ username }),
   setWebsite: (website) => set({ website }),
   setTempClickedField: (fields) => set({ tempClickedField: fields }),


### PR DESCRIPTION
## 🪄 변경 사항
- 마이페이지 API 연결
- 미이페이지 데이터 바인딩
- 프로필 편집 후 저장하면 서버에 데이터가 저장되도록 구현 
- api.d.ts 에서 isCover와 username 에는 옵셔널 연산자 `?` 를 사용


## 💡 반영 브랜치
- feat/mypage-api ➡️ main

## 🖼️ 결과 화면 (생략 가능)
<img width="956" alt="image" src="https://github.com/user-attachments/assets/3d03884a-7fc3-4e5d-9f8a-c3184f78a27c" />


## 💬 리뷰어에게 전할 말
- API 명세서에 따라 website, field, 프로필 이미지를 PUT이 아니라 POST를 사용하도록 수정할 예정입니다. 
- 마이페이지에서 label을 수정할 예정입니다. (이름 -> id, 별명 -> 이름) 