### PR TITLE
💄 feat/post-main-style : Timer 동적 시,분,초 넓이값 50px 고정 + 달력 년도 선택 색상 변경

### DIFF
--- a/src/components/Mui/Calender.tsx
+++ b/src/components/Mui/Calender.tsx
@@ -1,4 +1,3 @@
-import * as React from "react";
 import { LocalizationProvider } from "@mui/x-date-pickers/LocalizationProvider";
 import { AdapterDayjs } from "@mui/x-date-pickers/AdapterDayjs";
 import { DateCalendar } from "@mui/x-date-pickers";
@@ -22,6 +21,9 @@ export default function BasicDateCalendar() {
         },
       },
       "& .MuiPickersDay-today": {},
+      "& .MuiPickersYear-yearButton.Mui-selected": {
+        backgroundColor: "#7EACB5 !important",
+      },
     },
   };
 

--- a/src/routes/Main/LeftContents/TimerComponent/Timer.tsx
+++ b/src/routes/Main/LeftContents/TimerComponent/Timer.tsx
@@ -126,15 +126,21 @@ export default function Timer({
             </article>
             <span className="text-[20px] font-black">ㅡ</span>
             <article className="flex gap-1 text-5xl mt-[15px]">
-              <span>{hours < 10 ? `0${hours}` : hours}</span>
+              <span className="w-[50px]">
+                {hours < 10 ? `0${hours}` : hours}
+              </span>
 
               <span>:</span>
 
-              <span>{minutes < 10 ? `0${minutes}` : minutes}</span>
+              <span className="w-[50px]">
+                {minutes < 10 ? `0${minutes}` : minutes}
+              </span>
 
               <span>:</span>
 
-              <span>{seconds < 10 ? `0${seconds}` : seconds}</span>
+              <span className="w-[50px]">
+                {seconds < 10 ? `0${seconds}` : seconds}
+              </span>
             </article>
           </>
         ) : null}

--- a/src/routes/Main/RightComponent/RightContents.tsx
+++ b/src/routes/Main/RightComponent/RightContents.tsx
@@ -1,4 +1,3 @@
-import React from "react";
 import FriendList from "./FriendList";
 import BasicDateCalendar from "../../../components/Mui/Calender";
 


### PR DESCRIPTION
## 🪄 변경 사항
- Timer 동적 시,분,초 넓이값 50px 고정(이제 타이머 꿀렁꿀렁 거리지 않습니다!)
- 달력 년도 선택 색상 변경(#7EACB5)
- 그 외 안 쓰이는 import문 몇 개 삭제했습니다.

## 💡 반영 브랜치
- feat/post-main-style

## 🖼️ 결과 화면 (생략 가능)
![image](https://github.com/user-attachments/assets/5cc215cb-f2bd-43ea-b9e7-8d871320427a)

## 💬 리뷰어에게 전할 말
- 오늘은 여기까지.... 일찍 퇴근하겠슴다. (/ω＼)b