### PR TITLE
😎 feat: 에디터 - 원하는 채널 선택 가능, api 연결 완료

### DIFF
--- a/src/api/api.d.ts
+++ b/src/api/api.d.ts
@@ -1,4 +1,4 @@
-interface userType {
+export interface userType {
   role: string;
   emailVerified: boolean;
   banned: boolean;

--- a/src/components/editor/EditorModal.tsx
+++ b/src/components/editor/EditorModal.tsx
@@ -15,6 +15,7 @@ export default function EditorModal({ children }: ModalProps) {
     resetEditor,
     isDialogOpen,
     toggleDialog,
+    isShake,
   } = useEditorStore();
 
   const handleCancel = () => {
@@ -48,7 +49,7 @@ export default function EditorModal({ children }: ModalProps) {
           onClick={(e) => e.stopPropagation()} // 이벤트 버블링 방지
           className={`relative w-[1080px] min-h-[640px] max-w-[90%] max-h-[80%] rounded-[10px] overflow-hidden transition-transform duration-500 bg-gray-50 ${
             isOpen ? "scale-100" : "scale-90"
-          }`}
+          } ${isShake ? "animate-shake" : ""}`}
         >
           <div className="relative p-6">{children}</div>
         </div>

--- a/src/routes/Main/LeftContents/ButtonListComponent/ButtonListComponent.tsx
+++ b/src/routes/Main/LeftContents/ButtonListComponent/ButtonListComponent.tsx
@@ -32,7 +32,7 @@ export default function ButtonListComponent() {
         onClick={toggleHowTime}
       />
       <EditorModal>
-        <BlogEditor onSave={saveContent} />
+        <BlogEditor />
       </EditorModal>
     </section>
   );

--- a/src/store/postStore.ts
+++ b/src/store/postStore.ts
@@ -2,24 +2,44 @@ import { create } from "zustand";
 import { axiosInstance } from "../api/axios";
 
 interface PostStore {
-  post: (
-    title: string,
-    content: string,
-    image: string | null,
-    channelId: string
-  ) => Promise<boolean>;
-  isLoading: boolean;
-  error: string | null;
-  image: string | null;
-  channelId: string;
+  channels: { _id: string; name: string; description: string }[];
+  channelId: string | null; // 선택된 채널 ID
+
+  isLoading: boolean; // 로딩 상태
+  error: string | null; // 에러 메시지
+  setSelectedChannelId: (id: string) => void;
+  fetchChannels: () => Promise<void>; // 채널 리스트 GET 요청
+  post: (title: string, content: string, channelId: string) => Promise<boolean>; // POST 요청
 }
 
 export const usePostStore = create<PostStore>((set) => ({
+  channels: [],
+  channelId: null,
   isLoading: false,
   error: null,
-  image: null,
-  channelId: "",
-  post: async (title, content, image, channelId) => {
+
+  // 선택된 채널 ID 업데이트
+  setSelectedChannelId: (id: string) => set({ channelId: id }),
+
+  // 채널 리스트 GET 요청
+  fetchChannels: async () => {
+    try {
+      const response = await axiosInstance.get(
+        `${import.meta.env.VITE_API_URL}/channels`
+      );
+
+      if (response.data && response.data.length > 0) {
+        set({ channels: response.data }); // 채널 리스트 저장
+        set({ channelId: response.data[0]._id }); // 첫 번째 채널을 기본 선택
+        console.log("Fetched channels:", response.data);
+      }
+    } catch (error) {
+      console.error("Error fetching channels:", error);
+      set({ error: "채널 리스트 가져오기 실패" });
+    }
+  },
+
+  post: async (title: string, content: string, channelId: string) => {
     set({ isLoading: true, error: null });
     try {
       //JSON 문자열로 변환해서 title로 넣기
@@ -27,24 +47,23 @@ export const usePostStore = create<PostStore>((set) => ({
       //디버깅
       console.log("디버깅 체크", title, content, combinedTitle);
 
-      //axiosInstance 사용하기
-      const response = await axiosInstance
-        .post(`${import.meta.env.VITE_API_URL}/posts/create`, {
-          title: combinedTitle,
-          image: JSON.stringify(null),
-          channelId: "", //id값 넣어서 확인가능
-        })
-        .catch((err) => {
-          console.error(err);
-          throw new Error("POST 요청에 실패했습니다.");
-        });
+      const payload = {
+        title: combinedTitle, // 묶은 데이터를 title 필드로 전송
+        channelId, // 선택된 채널 ID 포함
+      };
 
+      //axiosInstance 사용하기
+      const response = await axiosInstance.post(
+        `${import.meta.env.VITE_API_URL}/posts/create`,
+        payload
+      );
       //성공
-      console.log("Post success!:", response.data);
+      console.log("Posting success:", response.data);
+      //임시 여기 이쁘게 바꿔보기.
       alert("Post submitted successfully!");
       return true;
     } catch (error: any) {
-      console.error("Error posting data:", error);
+      console.error("Posting Error:", error);
       set({ error: error.message });
       return false;
     } finally {

--- a/src/store/postStore.ts
+++ b/src/store/postStore.ts
@@ -7,7 +7,7 @@ interface PostStore {
     content: string,
     image: string | null,
     channelId: string
-  ) => Promise<void>;
+  ) => Promise<boolean>;
   isLoading: boolean;
   error: string | null;
   image: string | null;
@@ -32,7 +32,7 @@ export const usePostStore = create<PostStore>((set) => ({
         .post(`${import.meta.env.VITE_API_URL}/posts/create`, {
           title: combinedTitle,
           image: JSON.stringify(null),
-          channelId: "675aa3f8d3266e29a57e4c61",
+          channelId: "", //id값 넣어서 확인가능
         })
         .catch((err) => {
           console.error(err);
@@ -42,10 +42,11 @@ export const usePostStore = create<PostStore>((set) => ({
       //성공
       console.log("Post success!:", response.data);
       alert("Post submitted successfully!");
-      //실패
+      return true;
     } catch (error: any) {
       console.error("Error posting data:", error);
       set({ error: error.message });
+      return false;
     } finally {
       set({ isLoading: false });
     }

--- a/src/store/store.ts
+++ b/src/store/store.ts
@@ -8,26 +8,45 @@ interface EditorState {
   content: string;
   title: string;
   isDialogOpen: boolean;
+  isShake: boolean;
+  errorMessage: string;
+  thumbnail: File | null;
+  setShake: (v: boolean) => void;
+  setErrorMessage: (message: string) => void;
+  resetShakeAndError: () => void;
   toggleEditor: () => void;
   setContent: (content: string) => void;
   setTitle: (title: string) => void;
   toggleDialog: (open: boolean) => void;
   resetEditor: () => void;
+  setThumbnail: (thumbnail: File | null) => void;
 }
 
 export const useEditorStore = create<EditorState>((set) => ({
   isOpen: false,
   content: "",
   title: "",
+  thumbnail: null,
   isDialogOpen: false,
+  isShake: false,
+  errorMessage: "",
+  setShake: (v: boolean) => set({ isShake: v }),
+  setErrorMessage: (message: string) => set({ errorMessage: message }),
+  resetShakeAndError: () =>
+    set({
+      isShake: false,
+      errorMessage: "",
+    }),
+
   toggleEditor: () =>
     set((state: EditorState) => ({
       isOpen: !state.isOpen, // `state`의 타입이 EditorState임을 명시
     })),
   setContent: (content) => set({ content }),
+  setThumbnail: (thumbnail) => set({ thumbnail }),
   setTitle: (title) => set({ title }),
   toggleDialog: (open) => set({ isDialogOpen: open }),
-  resetEditor: () => set({ content: "", title: "" }),
+  resetEditor: () => set({ content: "", title: "", thumbnail: null }),
 }));
 
 // 메인페이지 몇 시간? 클릭시 상호작용 기능

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -48,6 +48,12 @@ export default {
             opacity: "1",
           },
         },
+        shake: {
+          "0%, 100%": { transform: "translateX(0)" },
+          "25%": { transform: "translateX(-10px)" },
+          "50%": { transform: "translateX(10px)" },
+          "75%": { transform: "translateX(-10px)" },
+        },
       },
       animation: {
         show: "show 1s ease-in-out forwards",
@@ -56,6 +62,7 @@ export default {
         spaceInDown_1s: "spaceInDown 1s ease-in-out forwards 1000ms",
         scaleInTopLeft: "scaleInTopLeft 0.3s ease-in-out forwards",
         scaleInTopRight: "scaleInTopRight 0.3s ease-in-out forwards",
+        shake: "shake 0.5s ease-in-out 2",
       },
     },
   },


### PR DESCRIPTION
## 🪄 변경 사항

**에디터 내에서 채널이 선택 가능해졌습니다. (api 바인딩 완료)**
에러처리를 shake로 변경했습니다.
제목이나 컨텐츠가 비었을 때 & 저장에 실패 했을 때 에디터 창이 흔들립니다.

## 💡 반영 브랜치

feat/editor-POSTAPI

## 🖼️ 결과 화면 (생략 가능)

![image](https://github.com/user-attachments/assets/8455371b-8056-45b1-b5db-68203700e77d)

![image](https://github.com/user-attachments/assets/0cb711dd-7224-44b2-9c41-ae018b7c6cef)


## 💬 리뷰어에게 전할 말

각 채널을 선택해서 글을 작성후에 저장하시면 개발자 도구를 통해서도 알 수 있고,
postman으로도 확인 가능합니다.

저장 완료시 나오는 alert는 더 이쁜걸로 바꿔보겠습니당.
