### PR TITLE
📝Feat/post main : 메인페이지 렌더링시 유저정보 업데이트 + ToDo 툴팁 추가 + 비로그인 유저 유저검색 기능 + 유저명 클릭시 userpage 이동

### DIFF
--- a/src/components/Modal/FriendManageModal.tsx
+++ b/src/components/Modal/FriendManageModal.tsx
@@ -99,7 +99,9 @@ export default function FriendManageModal() {
               alt="profile"
             />
             <Link
-              to={`/userpage/${userOne.username}`}
+              to={`/userpage/${
+                userOne.username ? userOne.username : userOne.fullName
+              }`}
               className="text-black text-lg font-medium font-['Inter']"
               onClick={close}
             >

--- a/src/components/Modal/FriendManageModal.tsx
+++ b/src/components/Modal/FriendManageModal.tsx
@@ -4,6 +4,8 @@ import { v4 as uuidv4 } from "uuid";
 import { useFriendModalStore } from "../../store/store";
 import { axiosInstance } from "../../api/axios";
 import { useLoginStore } from "../../store/API";
+import NonLoginFriendModal from "./NonLoginFriendModal";
+import { Link } from "react-router";
 
 export default function FriendManageModal() {
   // const [isHovered, setIsHovered] = useState<boolean>(false);
@@ -23,6 +25,7 @@ export default function FriendManageModal() {
 
   const setUser = useLoginStore((state) => state.setUser);
 
+  // API들(추후에 옮겨야함)
   const getUserAll = async () => {
     try {
       const userAll = (await axiosInstance.get<userType[]>(`/users/get-users`))
@@ -51,8 +54,6 @@ export default function FriendManageModal() {
 
   const deleteUnFollow = async (id: string) => {
     // 언팔로우 요청을 보내는 코드 안에 유저정보 업데이트 함수까지 실행시켜야 즉각적인 업데이트가 가능하다.
-    console.log(`${import.meta.env.VITE_API_URL}follow/delete`);
-    console.log(token);
     try {
       const unfollowed = (
         await axiosInstance.delete(`/follow/delete`, {
@@ -82,6 +83,7 @@ export default function FriendManageModal() {
     getUserAll();
     getAuthUser();
   }, []);
+  // API들(추후에 옮겨야함)
 
   const renderUsers = (userAll: userType[]) => (
     <div className="overflow-auto h-[415px] mt-3 scrollbar-hidden">
@@ -96,14 +98,20 @@ export default function FriendManageModal() {
               src="https://via.placeholder.com/50x50"
               alt="profile"
             />
-            <div>
-              <p className="text-sm font-semibold">
-                {userOne.fullName || "김김김"}
-              </p>
-              <p className="text-xs text-gray-500">
-                @{userOne.fullName || "buzzusborne"}
-              </p>
-            </div>
+            <Link
+              to={`/userpage/${userOne.username}`}
+              className="text-black text-lg font-medium font-['Inter']"
+              onClick={close}
+            >
+              <div>
+                <p className="text-sm font-semibold">
+                  {userOne.fullName || "김김김"}
+                </p>
+                <p className="text-xs text-gray-500">
+                  @{userOne.fullName || "buzzusborne"}
+                </p>
+              </div>
+            </Link>
           </div>
           {user?.following ? (
             user.following.find((e) => e.user === userOne._id) ? ( // following하고 있는 유저명과 로그인 유저가 일치하면 언팔로우 버튼 활성화
@@ -147,128 +155,113 @@ export default function FriendManageModal() {
     </div>
   );
 
-  /*
-  "::after": {
-                content: '"언팔로우"', // Hover 시 나타날 텍스트
-                position: "absolute",
-                top: "50%",
-                left: "50%",
-                transform: "translate(-50%, -50%)",
-                color: "#C96868",
-                opacity: 0,
-                transition: "none",
-              },
-              "&:hover": {
-                transition: "none",
-                border: "1px solid #C96868",
-                color: "transparent", // 기존 텍스트 숨기기
-                "::after": {
-                  opacity: 1, // Hover 시 텍스트 보이기
-                },
-              },
-  */
-
   return (
     <div className="fixed inset-0 z-40">
       <div
         className="absolute inset-0 bg-black bg-opacity-70"
         onClick={close}
       ></div>
-      <section className="absolute inset-1/2 w-[502px] h-[619px] transform -translate-x-1/2 -translate-y-1/2 bg-white rounded-2xl shadow py-4 pl-2">
-        <header className="flex justify-between p-4">
-          <h1 className="text-3xl font-bold text-gray-800">
-            {activeToggle === "all" ? "전체 목록" : "친구 목록"}
-          </h1>
-          <div className="relative w-32 h-10">
-            <div className="absolute inset-0 bg-gray-200 rounded-full"></div>
-            <div
-              className={`absolute top-0 w-[50%] h-full bg-[#7eacb5] rounded-full transition-transform duration-300 ${
-                activeToggle === "friend" ? "translate-x-0" : "translate-x-full"
-              }`}
-            ></div>
-            <div
-              className="absolute inset-y-0 left-4 flex items-center text-sm font-semibold text-center cursor-pointer text-white"
-              onClick={() => setActiveToggle("friend")}
-            >
-              친구
-            </div>
-            <div
-              className="absolute inset-y-0 right-4 flex items-center text-sm font-semibold text-center cursor-pointer text-white"
-              onClick={() => setActiveToggle("all")}
-            >
-              전체
-            </div>
-          </div>
-        </header>
-        <nav className="flex justify-around h-12 mt-5">
-          {activeToggle === "friend" ? (
-            <>
+      {token ? (
+        <section className="absolute inset-1/2 w-[502px] h-[619px] transform -translate-x-1/2 -translate-y-1/2 bg-white rounded-2xl shadow py-4 pl-2">
+          <header className="flex justify-between p-4">
+            <h1 className="text-3xl font-bold text-gray-800">
+              {activeToggle === "all" ? "전체 목록" : "친구 목록"}
+            </h1>
+            <div className="relative w-32 h-10">
+              <div className="absolute inset-0 bg-gray-200 rounded-full"></div>
               <div
-                className={`pb-2 cursor-pointer ${
-                  activeTab === "followers"
-                    ? "text-[#7eacb5] border-b-2 border-[#7eacb5]"
-                    : "text-gray-500"
+                className={`absolute top-0 w-[50%] h-full bg-[#7eacb5] rounded-full transition-transform duration-300 ${
+                  activeToggle === "friend"
+                    ? "translate-x-0"
+                    : "translate-x-full"
                 }`}
-                onClick={() => setActiveTab("followers")}
+              ></div>
+              <div
+                className="absolute inset-y-0 left-4 flex items-center text-sm font-semibold text-center cursor-pointer text-white"
+                onClick={() => setActiveToggle("friend")}
               >
-                팔로워
+                친구
               </div>
               <div
-                className={`pb-2 cursor-pointer ${
-                  activeTab === "following"
-                    ? "text-[#7eacb5] border-b-2 border-[#7eacb5]"
-                    : "text-gray-500"
-                }`}
-                onClick={() => setActiveTab("following")}
+                className="absolute inset-y-0 right-4 flex items-center text-sm font-semibold text-center cursor-pointer text-white"
+                onClick={() => setActiveToggle("all")}
               >
-                팔로잉
+                전체
               </div>
-            </>
-          ) : (
-            <>
-              <div className="w-[458px] h-12 pl-6 pr-2 py-2 mb-5 bg-white rounded-full shadow border border-gray-200 justify-start items-center gap-4 inline-flex">
-                <div className="w-full h-full grow shrink basis-0 flex-col justify-start items-start inline-flex">
-                  <div className="w-full h-full self-stretch text-black text-sm font-medium font-['Inter'] leading-tight">
-                    <input
-                      className="w-full h-full focus:outline-none"
-                      placeholder="검색"
-                      ref={inputRef}
-                      onKeyDown={(e) => {
-                        if (e.key === "Enter") ButtonRef.current?.click();
-                      }}
-                    />
+            </div>
+          </header>
+          <nav className="flex justify-around h-12 mt-5">
+            {activeToggle === "friend" ? (
+              <>
+                <div
+                  className={`pb-2 cursor-pointer ${
+                    activeTab === "followers"
+                      ? "text-[#7eacb5] border-b-2 border-[#7eacb5]"
+                      : "text-gray-500"
+                  }`}
+                  onClick={() => setActiveTab("followers")}
+                >
+                  팔로워
+                </div>
+                <div
+                  className={`pb-2 cursor-pointer ${
+                    activeTab === "following"
+                      ? "text-[#7eacb5] border-b-2 border-[#7eacb5]"
+                      : "text-gray-500"
+                  }`}
+                  onClick={() => setActiveTab("following")}
+                >
+                  팔로잉
+                </div>
+              </>
+            ) : (
+              <>
+                <div className="w-[458px] h-12 pl-6 pr-2 py-2 mb-5 bg-white rounded-full shadow border border-gray-200 justify-start items-center gap-4 inline-flex">
+                  <div className="w-full h-full grow shrink basis-0 flex-col justify-start items-start inline-flex">
+                    <div className="w-full h-full self-stretch text-black text-sm font-medium font-['Inter'] leading-tight">
+                      <input
+                        className="w-full h-full focus:outline-none"
+                        placeholder="검색"
+                        ref={inputRef}
+                        onKeyDown={(e) => {
+                          if (e.key === "Enter") ButtonRef.current?.click();
+                        }}
+                      />
+                    </div>
+                  </div>
+                  <div className="w-8 h-8 justify-start items-start flex">
+                    <div className="grow shrink basis-0 self-stretch p-1 bg-[#7eacb5] rounded-[100px] shadow justify-center items-center gap-2 flex">
+                      <button
+                        className="w-5 h-5 relative bg-[url(src/asset/images/Search.svg)]"
+                        ref={ButtonRef}
+                        onClick={() => {
+                          const searchUser = userAll.filter((e) =>
+                            e.fullName.includes(inputRef.current!.value!)
+                          );
+                          setSearchUser(searchUser);
+                        }}
+                      />
+                    </div>
                   </div>
                 </div>
-                <div className="w-8 h-8 justify-start items-start flex">
-                  <div className="grow shrink basis-0 self-stretch p-1 bg-[#7eacb5] rounded-[100px] shadow justify-center items-center gap-2 flex">
-                    <button
-                      className="w-5 h-5 relative bg-[url(src/asset/images/Search.svg)]"
-                      ref={ButtonRef}
-                      onClick={() => {
-                        const searchUser = userAll.filter((e) =>
-                          e.fullName.includes(inputRef.current!.value!)
-                        );
-                        setSearchUser(searchUser);
-                      }}
-                    />
-                  </div>
-                </div>
-              </div>
-            </>
-          )}
-        </nav>
-        {activeToggle === "friend"
-          ? renderUsers(
-              activeTab === "followers"
-                ? userAll.filter((e) =>
-                    user?.followers.some((j) => j.follower === e._id)
-                  )
-                : userAll.filter((e) =>
-                    user?.following.some((j) => j.user === e._id)
-                  )
-            )
-          : renderUsers(searchUser)}
-      </section>
+              </>
+            )}
+          </nav>
+          {activeToggle === "friend"
+            ? renderUsers(
+                activeTab === "followers"
+                  ? userAll.filter((e) =>
+                      user?.followers.some((j) => j.follower === e._id)
+                    )
+                  : userAll.filter((e) =>
+                      user?.following.some((j) => j.user === e._id)
+                    )
+              )
+            : renderUsers(searchUser)}
+        </section>
+      ) : (
+        <NonLoginFriendModal />
+      )}
     </div>
   );
 }

--- a/src/components/Modal/NonLoginFriendModal.tsx
+++ b/src/components/Modal/NonLoginFriendModal.tsx
@@ -1,0 +1,116 @@
+import { useEffect, useRef, useState } from "react";
+import { v4 as uuidv4 } from "uuid";
+import { useLoginStore } from "../../store/API";
+import { axiosInstance } from "../../api/axios";
+import { Link } from "react-router";
+
+export default function NonLoginFriendModal() {
+  const [userAll, setUserAll] = useState<userType[]>([]);
+  const setUser = useLoginStore((state) => state.setUser);
+
+  // 유저검색창 Ref객체
+  const inputRef = useRef<HTMLInputElement>(null);
+  const ButtonRef = useRef<HTMLButtonElement>(null);
+  const [searchUser, setSearchUser] = useState(userAll);
+
+  // API들(추후에 옮겨야함)
+  const getUserAll = async () => {
+    try {
+      const userAll = (await axiosInstance.get<userType[]>(`/users/get-users`))
+        .data;
+      setUserAll(userAll);
+      setSearchUser(userAll); // searchUser도 첫 페이지 렌더링시 모든 유저로 상태값 업데이트
+    } catch (error) {
+      console.log(error);
+    }
+  };
+
+  const getAuthUser = async () => {
+    const newUser = await (await axiosInstance.get(`/auth-user`)).data;
+    localStorage.setItem("LoginUserInfo", JSON.stringify(newUser));
+    setUser(newUser);
+  };
+  // API들(추후에 옮겨야함)
+
+  useEffect(() => {
+    getUserAll();
+    getAuthUser();
+  }, []);
+
+  const renderUsers = (userAll: userType[]) => (
+    <div className="overflow-auto h-[415px] mt-3 scrollbar-hidden">
+      {userAll.map((userOne, idx) => (
+        <div
+          key={uuidv4()}
+          className="flex items-center justify-between p-4 rounded-md hover:bg-gray-100"
+        >
+          <div className="flex items-center gap-4">
+            <img
+              className="w-12 h-12 rounded-full"
+              src="https://via.placeholder.com/50x50"
+              alt="profile"
+            />
+            <Link
+              to={`/userpage/${
+                userOne.username ? userOne.username : userOne.fullName
+              }`}
+              className="text-black text-lg font-medium font-['Inter']"
+              onClick={close}
+            >
+              <div>
+                <p className="text-sm font-semibold">
+                  {userOne.fullName || "김김김"}
+                </p>
+                <p className="text-xs text-gray-500">
+                  @{userOne.fullName || "buzzusborne"}
+                </p>
+              </div>
+            </Link>
+          </div>
+        </div>
+      ))}
+    </div>
+  );
+  return (
+    <section className="absolute inset-1/2 w-[502px] h-[619px] transform -translate-x-1/2 -translate-y-1/2 bg-white rounded-2xl shadow py-4 pl-2">
+      <header className="flex justify-between p-4">
+        <h1 className="text-3xl font-bold text-gray-800">전체 목록</h1>
+      </header>
+      <nav className="flex justify-around h-12 mt-5">
+        {
+          <>
+            <div className="w-[458px] h-12 pl-6 pr-2 py-2 mb-5 bg-white rounded-full shadow border border-gray-200 justify-start items-center gap-4 inline-flex">
+              <div className="w-full h-full grow shrink basis-0 flex-col justify-start items-start inline-flex">
+                <div className="w-full h-full self-stretch text-black text-sm font-medium font-['Inter'] leading-tight">
+                  <input
+                    className="w-full h-full focus:outline-none"
+                    placeholder="검색"
+                    ref={inputRef}
+                    onKeyDown={(e) => {
+                      if (e.key === "Enter") ButtonRef.current?.click();
+                    }}
+                  />
+                </div>
+              </div>
+              <div className="w-8 h-8 justify-start items-start flex">
+                <div className="grow shrink basis-0 self-stretch p-1 bg-[#7eacb5] rounded-[100px] shadow justify-center items-center gap-2 flex">
+                  <button
+                    className="w-5 h-5 relative bg-[url(src/asset/images/Search.svg)]"
+                    ref={ButtonRef}
+                    onClick={() => {
+                      const searchUser = userAll.filter((e) =>
+                        e.fullName.includes(inputRef.current!.value!)
+                      );
+                      setSearchUser(searchUser);
+                    }}
+                  />
+                </div>
+              </div>
+            </div>
+          </>
+        }
+      </nav>
+      {renderUsers(searchUser)}
+    </section>
+  );
+}

--- a/src/components/Modal/ProfileModal.tsx
+++ b/src/components/Modal/ProfileModal.tsx
@@ -23,7 +23,10 @@ export default function Modal({ y, x }: { x?: number; y?: number }) {
   const setToken = useLoginStore((state) => state.setToken);
 
   const logOut = async () => {
-    await axiosInstance.post(`/logout`).then((res) => console.log(res.status));
+    await axiosInstance
+      .post(`/logout`)
+      .then((res) => console.log(res.data))
+      .catch((err) => console.log(err));
     setUser(null);
     setToken(null);
     localStorage.setItem("LoginUserInfo", JSON.stringify(null));

--- a/src/routes/Main/CenterContents/ToDo/ToDo.tsx
+++ b/src/routes/Main/CenterContents/ToDo/ToDo.tsx
@@ -3,6 +3,7 @@ import { useToDoStore } from "../../../../store/store";
 import Pin from "./Pin";
 import ToDoListItem from "./ToDoListItem";
 import ToDoEditor from "./ToDoEditor";
+import { Tooltip } from "@mui/material";
 
 export default function ToDo() {
   // 메모장 핀 길이

--- a/src/routes/Main/CenterContents/ToDo/ToDoListItem.tsx
+++ b/src/routes/Main/CenterContents/ToDo/ToDoListItem.tsx
@@ -1,6 +1,7 @@
 import { useRef, useState } from "react";
 import { useToDoStore } from "../../../../store/store";
 import { DeleteOutline, DeleteRounded } from "@mui/icons-material";
+import { Tooltip } from "@mui/material";
 
 export default function ToDoListItem({
   findid,
@@ -25,70 +26,72 @@ export default function ToDoListItem({
   const inputRef = useRef<HTMLInputElement>(null);
 
   return (
-    <li className="w-100% h-[50px] border-b border-[#D0E5F9] hover:bg-[#e9e9e9] pl-[20px] px-[10px] flex items-center justify-between relative">
-      <article className="self-center flex gap-[18px]">
-        <input
-          ref={inputRef}
-          type="checkbox"
-          className={
-            "appearance-none w-[20px] h-[20px] border border-[#d9d9d9] rounded-[5px]]"
-          }
-          checked={ckeck}
-          onChange={() => {
-            // 체크시 로컬저장소랑 전역변수 체크상태 업데이트
-            const newToDoList = ToDoList.map((e) => {
-              // 리스트의 uuid와 일치하는 요소를 찾아 checked상태를 변경
-              if (e.id === findid) {
-                return { text: e.text, id: e.id, checked: !e.checked };
-              }
-              return e;
-            });
-            // 전역변수, 로컬저장소에 변경내용 저장
-            updateToDoListCheck(newToDoList);
-            localStorage.setItem("ToDoList", JSON.stringify(newToDoList));
-          }}
-        />
-        {ckeck ? (
-          <article
-            className="absolute top-[10px] left-[23px]"
-            onClick={() => {
-              // 체크 아이콘을 클릭하면 ref객체를 통해 체크박스가 클릭되도록 유도
-              inputRef.current?.click();
+    <Tooltip placement="right" arrow title={text}>
+      <li className="w-100% h-[50px] border-b border-[#D0E5F9] hover:bg-[#e9e9e9] pl-[20px] px-[10px] flex items-center justify-between relative">
+        <article className="self-center flex gap-[18px]">
+          <input
+            ref={inputRef}
+            type="checkbox"
+            className={
+              "appearance-none w-[20px] h-[20px] border border-[#d9d9d9] rounded-[5px]]"
+            }
+            checked={ckeck}
+            onChange={() => {
+              // 체크시 로컬저장소랑 전역변수 체크상태 업데이트
+              const newToDoList = ToDoList.map((e) => {
+                // 리스트의 uuid와 일치하는 요소를 찾아 checked상태를 변경
+                if (e.id === findid) {
+                  return { text: e.text, id: e.id, checked: !e.checked };
+                }
+                return e;
+              });
+              // 전역변수, 로컬저장소에 변경내용 저장
+              updateToDoListCheck(newToDoList);
+              localStorage.setItem("ToDoList", JSON.stringify(newToDoList));
             }}
+          />
+          {ckeck ? (
+            <article
+              className="absolute top-[10px] left-[23px]"
+              onClick={() => {
+                // 체크 아이콘을 클릭하면 ref객체를 통해 체크박스가 클릭되도록 유도
+                inputRef.current?.click();
+              }}
+            >
+              <img src="/src/asset/images/check_icon.svg" alt="체크 아이콘" />
+            </article>
+          ) : null}
+          <span
+            className={`font-medium w-[280px] truncate`}
+            style={{ color: `${ckeck ? color : ""}` }}
           >
-            <img src="/src/asset/images/check_icon.svg" alt="체크 아이콘" />
-          </article>
-        ) : null}
-        <span
-          className={`font-medium`}
-          style={{ color: `${ckeck ? color : ""}` }}
-        >
-          {text}
-        </span>
-        {ckeck ? (
-          <article className="w-[80%] absolute left-[40px] self-center">
-            <img src="/src/asset/images/line_through.svg" alt="빨간줄" />
-          </article>
-        ) : null}
-      </article>
+            {text}
+          </span>
+          {ckeck ? (
+            <article className="w-[80%] absolute left-[40px] self-center">
+              <img src="/src/asset/images/line_through.svg" alt="빨간줄" />
+            </article>
+          ) : null}
+        </article>
 
-      <button
-        onClick={() => {
-          deleteToDoList(index);
-          localStorage.setItem(
-            "ToDoList",
-            JSON.stringify(ToDoList.filter((_, i) => i !== index))
-          );
-        }}
-        onMouseEnter={() => setIsDeleteIconHovered(true)}
-        onMouseLeave={() => setIsDeleteIconHovered(false)}
-      >
-        {clickedIndex === index || isDeleteIconHovered ? (
-          <DeleteRounded sx={{ color: "#C96868" }} />
-        ) : (
-          <DeleteOutline sx={{ color: "#C96868" }} />
-        )}
-      </button>
-    </li>
+        <button
+          onClick={() => {
+            deleteToDoList(index);
+            localStorage.setItem(
+              "ToDoList",
+              JSON.stringify(ToDoList.filter((_, i) => i !== index))
+            );
+          }}
+          onMouseEnter={() => setIsDeleteIconHovered(true)}
+          onMouseLeave={() => setIsDeleteIconHovered(false)}
+        >
+          {clickedIndex === index || isDeleteIconHovered ? (
+            <DeleteRounded sx={{ color: "#C96868" }} />
+          ) : (
+            <DeleteOutline sx={{ color: "#C96868" }} />
+          )}
+        </button>
+      </li>
+    </Tooltip>
   );
 }

--- a/src/routes/Main/LeftContents/ButtonListComponent/ButtonListComponent.tsx
+++ b/src/routes/Main/LeftContents/ButtonListComponent/ButtonListComponent.tsx
@@ -3,6 +3,7 @@ import { useHowTimeStore } from "../../../../store/store";
 import LinkButton from "./LinkButton";
 import EditorModal from "../../../../components/editor/EditorModal";
 import BlogEditor from "../../../../components/editor/BlogEditor";
+import { useLoginStore } from "../../../../store/API";
 
 export default function ButtonListComponent() {
   const { toggleEditor } = useEditorStore();
@@ -12,6 +13,8 @@ export default function ButtonListComponent() {
     toggleEditor();
   };
   const { open } = useFriendModalStore();
+
+  const token = useLoginStore((state) => state.token);
 
   return (
     <section className="flex gap-[20px]">
@@ -23,7 +26,7 @@ export default function ButtonListComponent() {
       <LinkButton icon={"/src/asset/images/Chat.svg"} title={"게시판"} />
       <LinkButton
         icon={"/src/asset/images/Group-person.svg"}
-        title={"친구관리"}
+        title={token ? "친구관리" : "유저 검색"}
         onClick={open}
       />
       <LinkButton

--- a/src/routes/Main/Main.tsx
+++ b/src/routes/Main/Main.tsx
@@ -14,6 +14,7 @@ import { styled } from "@mui/material";
 import FriendManageModal from "../../components/Modal/FriendManageModal";
 import { useEffect } from "react";
 import { useLoginStore } from "../../store/API";
+import { axiosInstance } from "../../api/axios";
 
 const HeartStyle = styled("div")`
   @keyframes float {
@@ -41,6 +42,21 @@ export default function Main() {
     (state) => state.setTrophyModalViewed
   );
   const modal = useFriendModalStore((s) => s.modal);
+
+  // 메인페이지 들어올 떄 마다 유저정보 업데이트
+  const setUser = useLoginStore((state) => state.setUser);
+  const getAuthUser = async () => {
+    const newUser = await (await axiosInstance.get(`/auth-user`)).data;
+    console.log(newUser === "");
+    localStorage.setItem(
+      "LoginUserInfo",
+      JSON.stringify(newUser === "" ? null : newUser)
+    );
+    setUser(newUser);
+  };
+  useEffect(() => {
+    getAuthUser();
+  }, []);
 
   return (
     <section>


### PR DESCRIPTION
## 🪄 변경 사항
- 메인 페이지 렌더링 마다 유저 정보 업데이트 + 로그아웃 시 로컬 저장소에 nulll값이 아닌 ""값으로 저장되는 현상 수정(그런데 전역번수는 ""으로 저장되는거 같음..)
- ToDo ListItem 호버시 무슨 내용이 적혔는지 보여주는 툴팁 적용
- 팔로워/팔로잉/전체검색 기능에 유저 이름 클릭하면 userpage로 이동(url파라미터에 해당 유저의 username 달아서 보냄(없으면 fullname) -> 이걸로 데이터 불러오면 됩니당) -> 그런데 최초 회원가입시 username이 없는데 fullname으로 불러오는 상황에서 fullname이 영어가 아니거나, 중복되는 fullname이 있으면 데이터를 불러오는 과정에서 오류를 일으킬 걸로 보입니다.. username이랑 fullname의 용도를 다시 정하고 둘 중 하나는 중복 사용을 불가능하게 만들어야 할 거 같습니다.(제 생각에는 username은 중복으로 작성 가능 + 한글 가능, fullname은 유저끼리 중복 불가능 + 영어만 가능 이렇게 만드는게 좋을거 같습니당) -> 추후에 정해지면 url파라미터값 수정하겠습니다(현재 적용 페이지 : FriendManageModal.tsx, NonLoginFriendModal.tsx)
- userpage url파라미터 정보 수정(username 또는 userOne) + 비로그인 유저는 친구목록이 아닌 유저검색으로 컴포넌트 변경(새로 만듬)
- 비로그인 유저는 친구검색 버튼 텍스트 유저검색 으로 변경

## 💡 반영 브랜치
- Feat/post main

## 🖼️ 결과 화면 (생략 가능)
- ToDo리스트 hover 툴팁
![image](https://github.com/user-attachments/assets/1d39ea7f-18ad-486d-95ce-03ee78873781)
- 비로그인 유저
![image](https://github.com/user-attachments/assets/55592d00-913f-4fc6-a511-22d9bdb51a79)
![image](https://github.com/user-attachments/assets/30d9b5a8-d030-4cd4-be6d-5e1f54c4a269)
- 페이지 이동
이름 클릭시 이동
![image](https://github.com/user-attachments/assets/49bb68c6-78ed-44a9-8ec9-0f0ad45cd2ce)
![image](https://github.com/user-attachments/assets/bd85208a-cb64-4019-aeb6-f72131c3157a)

## 💬 리뷰어에게 전할 말
- ╰(*°▽°*)╯