### PR TITLE
📝 feat/post-main : 온라인 유저 리스트 데이터바인딩(커버 이미지는 아직 구현X)

### DIFF
--- a/src/components/Mui/List.tsx
+++ b/src/components/Mui/List.tsx
@@ -9,6 +9,7 @@ import Modal from "../Modal/ProfileModal";
 import { BorderBottom } from "@mui/icons-material";
 import { axiosInstance } from "../../api/axios";
 import { useEffect, useState } from "react";
+import { userType } from "../../api/api";
 
 // 친구목록에 사용하는 리스트 MUI
 export default function CheckboxListSecondary() {
@@ -74,7 +75,7 @@ export default function CheckboxListSecondary() {
     },
   };
 
-  const [onlineUser, setOnlineUser] = useState([]);
+  const [onlineUser, setOnlineUser] = useState<userType[] | []>([]);
   const getOnlineUser = async () => {
     const onlineUserData = await axiosInstance.get(
       `${import.meta.env.VITE_API_URL}/users/online-users`
@@ -91,10 +92,10 @@ export default function CheckboxListSecondary() {
     <div className="relative ">
       <List id="mainListModal" dense sx={styles.list}>
         {onlineUser.map((value) => {
-          const labelId = `checkbox-list-secondary-label-${value}`;
+          const labelId = `checkbox-list-secondary-label-${value._id}`;
           return (
             <ListItem
-              key={value}
+              key={value._id}
               // secondaryAction={
               //   <Checkbox
               //     edge="end"
@@ -106,7 +107,7 @@ export default function CheckboxListSecondary() {
               disablePadding
             >
               <ListItemButton
-                key={value}
+                key={value._id}
                 onClick={(e) => {
                   e.stopPropagation();
                   handleItemClick(e);
@@ -114,11 +115,11 @@ export default function CheckboxListSecondary() {
               >
                 <ListItemAvatar>
                   <Avatar
-                    alt={`Avatar n°${value + 1}`}
-                    src={`/static/images/avatar/${value + 1}.jpg`}
+                    alt={`Avatar n°${value._id + 1}`}
+                    src={`/static/images/avatar/${value._id + 1}.jpg`}
                   />
                 </ListItemAvatar>
-                <ListItemText id={labelId} primary={`Line item ${value + 1}`} />
+                <ListItemText id={labelId} primary={`${value.fullName}`} />
               </ListItemButton>
             </ListItem>
           );


### PR DESCRIPTION
## 🪄 변경 사항
- 온라인 유저 리스트 데이터바인딩(커버 이미지는 아직 구현X)
- 유저 리스트 클릭시 모달창 데이터 바인딩은 아직 안했고 프로필 보기도 주소 연결을 아직 안했습니다.
- 오늘 일찍 자고 내일 다시 할게용 ㅎ

## 💡 반영 브랜치
- feat/post-main

## 🖼️ 결과 화면 (생략 가능)
![image](https://github.com/user-attachments/assets/718172be-7ef3-48e4-bf46-c0db5798955b)
![image](https://github.com/user-attachments/assets/4bc841d7-edbc-4b72-9648-a12789772c9a)

## 💬 리뷰어에게 전할 말
- 주말 마무리 잘 하세용⭐💡