### PR TITLE
📝 feat/post-main-online : 온라인 유저 기능 데이터바인딩 거의 완료 + FriendList.tsx에서 OnlineList.tsx로 파일명 변경

### DIFF
--- a/src/api/api.d.ts
+++ b/src/api/api.d.ts
@@ -34,6 +34,7 @@ export interface userType {
     website: string;
     field: string;
   };
+  coverImage?: string;
   username?: string;
 }
 

--- a/src/components/Modal/ProfileModal.tsx
+++ b/src/components/Modal/ProfileModal.tsx
@@ -4,14 +4,21 @@ import { useprofileModalStore } from "../../store/store";
 import { axiosInstance } from "../../api/axios";
 import { useLoginStore } from "../../store/API";
 
-export default function Modal({ y, x }: { x?: number; y?: number }) {
+export default function Modal({
+  y,
+  x,
+  onlineFullname,
+  onlineCoverImg,
+}: {
+  x?: number;
+  y?: number;
+  onlineFullname?: string;
+  onlineCoverImg?: string;
+}) {
   const modal = useprofileModalStore((s) => s.modal);
   const type = useprofileModalStore((s) => s.type);
   const close = useprofileModalStore((s) => s.close);
   const contentRef = useRef<HTMLDivElement>(null);
-
-  //임시 username
-  const username = "testuser";
 
   // 유저토큰값(로그인, 로그아웃 창 트리거 용도도)
   const token = useLoginStore((state) => state.token);
@@ -75,8 +82,12 @@ export default function Modal({ y, x }: { x?: number; y?: number }) {
               <div className="w-[42px] h-[42px] left-0 top-0 absolute">
                 <div className="w-[42px] h-[42px] left-0 top-0 absolute bg-gradient-to-b from-[#fcd7b4] to-[#ffc2af] rounded-full" />
                 <img
-                  className="w-11 h-11 left-0 top-[-2px] absolute"
-                  src="/src/asset/images/profile.svg"
+                  className="w-11 h-11 left-0 top-[-2px] absolute rounded-full"
+                  src={
+                    type === "header"
+                      ? "/src/asset/images/profile.svg"
+                      : onlineCoverImg
+                  }
                 />
               </div>
             </div>
@@ -88,7 +99,7 @@ export default function Modal({ y, x }: { x?: number; y?: number }) {
                       ? user?.fullName
                         ? user.fullName
                         : `익명`
-                      : "친구이름"}
+                      : onlineFullname}
                   </div>
                 </div>
               </div>
@@ -115,7 +126,7 @@ export default function Modal({ y, x }: { x?: number; y?: number }) {
                   </Link>
                 ) : (
                   <Link
-                    to={`./userpage/${username}`}
+                    to={`./userpage/${onlineFullname}`}
                     className="text-black text-lg font-medium font-['Inter']"
                     onClick={close}
                   >

--- a/src/components/Mui/List.tsx
+++ b/src/components/Mui/List.tsx
@@ -8,7 +8,7 @@ import { useprofileModalStore } from "../../store/store";
 import Modal from "../Modal/ProfileModal";
 import { BorderBottom } from "@mui/icons-material";
 import { axiosInstance } from "../../api/axios";
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { userType } from "../../api/api";
 
 // 친구목록에 사용하는 리스트 MUI
@@ -30,8 +30,18 @@ export default function CheckboxListSecondary() {
   // 모달 창 store
   const { type, open, modal, close } = useprofileModalStore();
   const [x, setX] = useState(0);
+  const [onlineFullname, setOnlineFullname] = useState("");
+  const [onlineCoverImg, setOnlineCoverImg] = useState("");
 
-  const handleItemClick = (e: React.MouseEvent<HTMLDivElement, MouseEvent>) => {
+  const handleItemClick = (
+    e: React.MouseEvent<HTMLDivElement, MouseEvent>,
+    fullname: string,
+    coverImg: string
+  ) => {
+    setOnlineFullname(() => fullname);
+    setOnlineCoverImg(() => coverImg);
+    console.log(onlineFullname);
+    console.log(onlineCoverImg);
     const rect = e.currentTarget.getBoundingClientRect();
     if (!modal) {
       open("list");
@@ -110,13 +120,23 @@ export default function CheckboxListSecondary() {
                 key={value._id}
                 onClick={(e) => {
                   e.stopPropagation();
-                  handleItemClick(e);
+                  handleItemClick(
+                    e,
+                    value.fullName,
+                    value.coverImage
+                      ? value.coverImage
+                      : `/src/asset/images/profile.svg`
+                  );
                 }}
               >
                 <ListItemAvatar>
                   <Avatar
                     alt={`Avatar n°${value._id + 1}`}
-                    src={`/static/images/avatar/${value._id + 1}.jpg`}
+                    src={
+                      value.coverImage
+                        ? value.coverImage
+                        : `/src/asset/images/profile.svg`
+                    }
                   />
                 </ListItemAvatar>
                 <ListItemText id={labelId} primary={`${value.fullName}`} />
@@ -125,7 +145,14 @@ export default function CheckboxListSecondary() {
           );
         })}
       </List>
-      {modal && type === "list" && <Modal y={-42} x={x} />}
+      {modal && type === "list" && (
+        <Modal
+          y={-42}
+          x={x}
+          onlineFullname={onlineFullname}
+          onlineCoverImg={onlineCoverImg}
+        />
+      )}
     </div>
   );
 }

--- a/src/routes/Main/RightComponent/OnlineList.tsx
+++ b/src/routes/Main/RightComponent/OnlineList.tsx
@@ -1,6 +1,6 @@
 import CheckboxListSecondary from "../../../components/Mui/List";
 
-export default function FriendList() {
+export default function OnlineList() {
   return (
     <>
       <article className="w-[22rem] shadow-xl rounded-[10px] mb-[24px]">

--- a/src/routes/Main/RightComponent/RightContents.tsx
+++ b/src/routes/Main/RightComponent/RightContents.tsx
@@ -1,10 +1,10 @@
-import FriendList from "./FriendList";
+import OnlineList from "./OnlineList";
 import BasicDateCalendar from "../../../components/Mui/Calender";
 
 export default function RightContents() {
   return (
     <section>
-      <FriendList />
+      <OnlineList />
       <BasicDateCalendar />
     </section>
   );


### PR DESCRIPTION
## 🪄 변경 사항
- 온라인 유저 기능 데이터바인딩 거의 완료 + FriendList.tsx에서 OnlineList.tsx로 파일명 변경
- 유저 이미지도 이제 데이터바인딩 됩니다

## 💡 반영 브랜치
- feat/post-main-online

## 🖼️ 결과 화면 (생략 가능)
![image](https://github.com/user-attachments/assets/c703744c-bf49-4e61-9062-0794dbdf8dd4)
![image](https://github.com/user-attachments/assets/18d1db67-7a0d-4746-b48a-7e9502af6cbc)

## 💬 리뷰어에게 전할 말
- 팔로우 유저도 데이터바인딩 하고 나면 이제 유저 페이지 데이터바인딩도 하겠습니다!!