### PR TITLE
Feat: 에디터 이미지 바인딩 & 오류 수정

### DIFF
--- a/src/api/api.d.ts
+++ b/src/api/api.d.ts
@@ -57,6 +57,7 @@ export interface Post_T {
   likes: string[];
   title: string; //Title_T가 string으로 들어옴
   image: string;
+  imageUrl?: string;
 }
 
 type Author_T = {

--- a/src/api/api.d.ts
+++ b/src/api/api.d.ts
@@ -48,15 +48,20 @@ interface followType {
   __v: number;
 }
 
-export type Post_T = {
+export interface Post_T {
   _id: string;
-  author: Author_T;
-  comments: Comments_T[];
+  title: string; // JSON.stringify로 묶인 title과 content
+  channel: string | null;
+  likes: string[];
+  comments: string[];
   createdAt: string;
   updatedAt: string;
-  likes: Likes_T[];
-  title: string; //Title_T가 string으로 들어옴
-};
+  author: {
+    fullName: string;
+    coverImage: string; // 작성자 프로필 이미지
+  };
+  imageUrl?: string; // 게시글 썸네일 이미지 URL
+}
 
 type Author_T = {
   fullName: string;

--- a/src/components/Community/PostPreview.tsx
+++ b/src/components/Community/PostPreview.tsx
@@ -1,8 +1,6 @@
 import { Post_T, Title_T } from "../../api/api";
 import FavoriteIcon from "@mui/icons-material/Favorite";
 import ChatIcon from "@mui/icons-material/Chat";
-import { usePostStore } from "../../store/postStore";
-import { useEffect, useState } from "react";
 
 type Props = {
   preview: Post_T;
@@ -14,20 +12,6 @@ export default function PostPreview({ preview }: Props) {
 
   // title 파싱한 객체(여기에 제목, 내용 들어가있고, 추후에 여러 컨텐츠들 추가할 예정 - 목표 달성 트로피 표시 등등)
   const parsedTitle: Title_T = JSON.parse(preview.title);
-
-  const { image } = usePostStore();
-
-  const [currentImage, setCurrentImage] = useState<string | null>(null);
-
-  useEffect(() => {
-    // image 상태가 존재하면 썸네일 이미지에 적용
-    if (image) {
-      const imageUrl = URL.createObjectURL(image); // File 객체를 브라우저 URL로 변환
-      setCurrentImage(imageUrl);
-    } else {
-      setCurrentImage(preview.imageUrl || sampleImgUrl); // API 데이터나 기본 이미지 사용
-    }
-  }, [image, preview.imageUrl]);
 
   // 날짜를 'YYYY년 MM월 DD일' 형식으로 변환하는 함수
   function formatDateToKorean(dateString: string): string {

--- a/src/components/Community/PostPreview.tsx
+++ b/src/components/Community/PostPreview.tsx
@@ -1,6 +1,8 @@
 import { Post_T, Title_T } from "../../api/api";
 import FavoriteIcon from "@mui/icons-material/Favorite";
 import ChatIcon from "@mui/icons-material/Chat";
+import { usePostStore } from "../../store/postStore";
+import { useEffect, useState } from "react";
 
 type Props = {
   preview: Post_T;
@@ -12,6 +14,20 @@ export default function PostPreview({ preview }: Props) {
 
   // title 파싱한 객체(여기에 제목, 내용 들어가있고, 추후에 여러 컨텐츠들 추가할 예정 - 목표 달성 트로피 표시 등등)
   const parsedTitle: Title_T = JSON.parse(preview.title);
+
+  const { image } = usePostStore();
+
+  const [currentImage, setCurrentImage] = useState<string | null>(null);
+
+  useEffect(() => {
+    // image 상태가 존재하면 썸네일 이미지에 적용
+    if (image) {
+      const imageUrl = URL.createObjectURL(image); // File 객체를 브라우저 URL로 변환
+      setCurrentImage(imageUrl);
+    } else {
+      setCurrentImage(preview.imageUrl || sampleImgUrl); // API 데이터나 기본 이미지 사용
+    }
+  }, [image, preview.imageUrl]);
 
   // 날짜를 'YYYY년 MM월 DD일' 형식으로 변환하는 함수
   function formatDateToKorean(dateString: string): string {
@@ -28,7 +44,7 @@ export default function PostPreview({ preview }: Props) {
       {/* 썸네일 이미지 */}
       <div className="relative aspect-video">
         <img
-          src={sampleImgUrl}
+          src={currentImage || sampleImgUrl}
           alt={parsedTitle.title}
           className="object-cover w-full h-full"
         />
@@ -52,7 +68,7 @@ export default function PostPreview({ preview }: Props) {
         <div className="flex items-center">
           <FavoriteIcon sx={{ fontSize: 14, marginRight: 0.6 }} />
           {preview.likes.length}
-          <ChatIcon sx={{ fontSize: 14, marginRight: 0.6, marginLeft: 1.5}} />
+          <ChatIcon sx={{ fontSize: 14, marginRight: 0.6, marginLeft: 1.5 }} />
           {preview.comments.length}
         </div>
         <div className="flex items-center ">

--- a/src/components/editor/BlogEditor.tsx
+++ b/src/components/editor/BlogEditor.tsx
@@ -32,6 +32,8 @@ export default function BlogEditor() {
     error,
     isLoading,
     channelId,
+    setImage,
+    image,
   } = usePostStore();
 
   useEffect(() => {
@@ -59,7 +61,7 @@ export default function BlogEditor() {
     //content 적용시키기
     const removePtags = removeHtml(content);
 
-    const success = await post(title, removePtags, channelId || "");
+    const success = await post(title, removePtags, channelId || "", image);
 
     if (success) {
       resetEditor();
@@ -190,6 +192,29 @@ export default function BlogEditor() {
           placeholder="제목을 입력하세요..."
           className="w-full pb-2 pl-3 text-3xl font-semibold text-black placeholder-gray-600 bg-transparent border-b border-white/30 focus:outline-none"
         />
+        {/* 파일 업로드 테스트용 input */}
+        <div className="pb-2">
+          <form>
+            <label
+              htmlFor="file-upload"
+              className="block text-md font-semibold text-gray-600 mb-1"
+            >
+              테스트용 파일 업로드
+            </label>
+            <input
+              id="file-upload"
+              type="file"
+              accept="image/*"
+              className="w-full text-sm text-gray-600 file:mr-4 file:py-1 file:px-2 file:rounded file:border-0 file:text-sm file:bg-[#7EACB5] file:text-white hover:file:bg-[#96CCD6] transition"
+              onChange={(e) => {
+                e.preventDefault();
+                const file = e.target.files?.[0] || null;
+                setImage(file);
+                console.log("이미지파일 디버깅용:", file);
+              }}
+            />
+          </form>
+        </div>
         {/* Stack 채널 선택 */}
         <Stack
           direction="column"

--- a/src/components/editor/BlogEditor.tsx
+++ b/src/components/editor/BlogEditor.tsx
@@ -22,6 +22,7 @@ export default function BlogEditor() {
     errorMessage,
     setErrorMessage,
     resetShakeAndError,
+    handleCancel,
   } = useEditorStore();
 
   const {
@@ -68,15 +69,6 @@ export default function BlogEditor() {
       toggleEditor();
     } else {
       handleError("저장에 실패했습니다.");
-    }
-  };
-
-  const handleCancel = () => {
-    if ((content.trim() && content.trim() !== "<p><br></p>") || title.trim()) {
-      toggleDialog(true); // ConfirmDialog 열기
-    } else {
-      resetEditor();
-      toggleEditor(); // 내용이 없으면 바로 닫기
     }
   };
 
@@ -173,7 +165,7 @@ export default function BlogEditor() {
             {isLoading ? "저장 중..." : "저장하기"}
           </Button>
           <Button
-            onClick={handleCancel}
+            onClick={() => handleCancel(setImage)}
             variant="custom"
             size="md"
             className="font-normal transition bg-[#D6D6D6] hover:bg-[#C96868] w-[40px] h-[40px]"
@@ -194,13 +186,15 @@ export default function BlogEditor() {
         />
         {/* 파일 업로드 테스트용 input */}
         <div className="relative pb-2">
-          <form>
+          <form className="flex items-center">
+            {/* 버튼 디자인 */}
             <label
               htmlFor="file-upload"
-              className="inline-block relative left-[10px] top-[5px] cursor-pointer text-white text-[14px] bg-[#7EACB5] px-2 py-2 rounded-[10px] hover:bg-[#96CCD6] transition"
+              className=" ml-[10px] inline-block cursor-pointer text-white text-[12px] bg-[#7EACB5] px-2 py-2 rounded-[10px] hover:bg-[#96CCD6] transition"
             >
               썸네일
             </label>
+            {/* 파일 업로드 input */}
             <input
               id="file-upload"
               type="file"
@@ -209,12 +203,19 @@ export default function BlogEditor() {
               onChange={(e) => {
                 e.preventDefault();
                 const file = e.target.files?.[0] || null;
-                //이미지 불러오기
                 setImage(file);
               }}
             />
+            {/* 파일 이름 표시*/}
+            <span
+              id="file-name-display"
+              className="ml-3 text-gray-600 text-sm truncate max-w-[150px]"
+            >
+              {image ? image.name : "파일을 선택하세요"}
+            </span>
           </form>
         </div>
+
         {/* Stack 채널 선택 */}
         <Stack
           direction="column"

--- a/src/components/editor/BlogEditor.tsx
+++ b/src/components/editor/BlogEditor.tsx
@@ -193,24 +193,24 @@ export default function BlogEditor() {
           className="w-full pb-2 pl-3 text-3xl font-semibold text-black placeholder-gray-600 bg-transparent border-b border-white/30 focus:outline-none"
         />
         {/* 파일 업로드 테스트용 input */}
-        <div className="pb-2">
+        <div className="relative pb-2">
           <form>
             <label
               htmlFor="file-upload"
-              className="block text-md font-semibold text-gray-600 mb-1"
+              className="inline-block relative left-[10px] top-[5px] cursor-pointer text-white text-[14px] bg-[#7EACB5] px-2 py-2 rounded-[10px] hover:bg-[#96CCD6] transition"
             >
-              테스트용 파일 업로드
+              썸네일
             </label>
             <input
               id="file-upload"
               type="file"
               accept="image/*"
-              className="w-full text-sm text-gray-600 file:mr-4 file:py-1 file:px-2 file:rounded file:border-0 file:text-sm file:bg-[#7EACB5] file:text-white hover:file:bg-[#96CCD6] transition"
+              className="hidden"
               onChange={(e) => {
                 e.preventDefault();
                 const file = e.target.files?.[0] || null;
+                //이미지 불러오기
                 setImage(file);
-                console.log("이미지파일 디버깅용:", file);
               }}
             />
           </form>

--- a/src/components/editor/EditorModal.tsx
+++ b/src/components/editor/EditorModal.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import { useEditorStore } from "../../store/store";
 import ConfirmDialog from "./ConfirmDialog";
+import { usePostStore } from "../../store/postStore";
 
 interface ModalProps {
   children?: React.ReactNode;
@@ -10,22 +11,15 @@ export default function EditorModal({ children }: ModalProps) {
   const {
     isOpen,
     toggleEditor,
-    content,
-    title,
+
     resetEditor,
     isDialogOpen,
     toggleDialog,
     isShake,
+    handleCancel,
   } = useEditorStore();
 
-  const handleCancel = () => {
-    if ((content.trim() && content.trim() !== "<p><br></p>") || title.trim()) {
-      toggleDialog(true); // ConfirmDialog 열기
-    } else {
-      resetEditor();
-      toggleEditor(); // 내용이 없으면 바로 닫기
-    }
-  };
+  const { setImage } = usePostStore();
 
   const confirmClose = () => {
     resetEditor();
@@ -43,7 +37,7 @@ export default function EditorModal({ children }: ModalProps) {
         className={`fixed inset-0 bg-black bg-opacity-75 z-40 flex items-center justify-center transition-opacity duration-500 ${
           isOpen ? "opacity-100" : "opacity-0 pointer-events-none"
         }`}
-        onClick={handleCancel}
+        onClick={() => handleCancel(setImage)}
       >
         <div
           onClick={(e) => e.stopPropagation()} // 이벤트 버블링 방지

--- a/src/routes/Community/Community.tsx
+++ b/src/routes/Community/Community.tsx
@@ -61,24 +61,24 @@ export default function Community({ channelName = "sw" }: Props) {
     <>
       <nav className="mt-[80px] flex py-3 items-center text-lg ">
         <Tooltip title="소프트웨어 개발" arrow>
-        <div className="mr-4 text-white bg-[#7EACB5] hover:bg-black hover:text-white transition-colors font-bold px-3 py-1 rounded-[10px] w-16 text-center opacity-80 ">
-          <Link to="/community/sw" >SW</Link>
-        </div>
+          <div className="mr-4 text-white bg-[#7EACB5] hover:bg-black hover:text-white transition-colors font-bold px-3 py-1 rounded-[10px] w-16 text-center opacity-80 ">
+            <Link to="/community/sw">SW</Link>
+          </div>
         </Tooltip>
         <Tooltip title="시스템/인프라" arrow>
-        <div className="mr-4 text-white bg-[#7EACB5] hover:bg-black hover:text-white transition-colors font-bold px-3 py-1 rounded-[10px] w-16 text-center opacity-80">
-          <Link to="/community/si">SI</Link>
-        </div>
+          <div className="mr-4 text-white bg-[#7EACB5] hover:bg-black hover:text-white transition-colors font-bold px-3 py-1 rounded-[10px] w-16 text-center opacity-80">
+            <Link to="/community/si">SI</Link>
+          </div>
         </Tooltip>
         <Tooltip title="데이터/AI 개발" arrow>
-        <div className="mr-4 text-white bg-[#7EACB5] hover:bg-black hover:text-white transition-colors font-bold px-3 py-1 rounded-[10px] w-16 text-center opacity-80">
-          <Link to="/community/da">DA</Link>
-        </div>
+          <div className="mr-4 text-white bg-[#7EACB5] hover:bg-black hover:text-white transition-colors font-bold px-3 py-1 rounded-[10px] w-16 text-center opacity-80">
+            <Link to="/community/da">DA</Link>
+          </div>
         </Tooltip>
         <Tooltip title="게임/QA" arrow>
-        <div className="text-white bg-[#7EACB5] hover:bg-black hover:text-white transition-colors font-bold px-3 py-1 rounded-[10px] w-16 text-center opacity-80">
-          <Link to="/community/ge">GE</Link>
-        </div>
+          <div className="text-white bg-[#7EACB5] hover:bg-black hover:text-white transition-colors font-bold px-3 py-1 rounded-[10px] w-16 text-center opacity-80">
+            <Link to="/community/ge">GE</Link>
+          </div>
         </Tooltip>
       </nav>
       <main className="grid gap-9 grid-cols-[repeat(auto-fill,minmax(300px,1fr))] mt-8 mb-6">

--- a/src/store/store.ts
+++ b/src/store/store.ts
@@ -13,6 +13,7 @@ interface EditorState {
   isShake: boolean;
   errorMessage: string;
   thumbnail: File | null;
+  handleCancel: (setImage: (file: File | null) => void) => void;
   closeLoginDialog: () => void;
   setShake: (v: boolean) => void;
   setErrorMessage: (message: string) => void;
@@ -25,7 +26,7 @@ interface EditorState {
   setThumbnail: (thumbnail: File | null) => void;
 }
 
-export const useEditorStore = create<EditorState>((set) => ({
+export const useEditorStore = create<EditorState>((set, get) => ({
   isOpen: false,
   isAlertOpen: false,
   content: "",
@@ -58,6 +59,18 @@ export const useEditorStore = create<EditorState>((set) => ({
   setTitle: (title) => set({ title }),
   toggleDialog: (open) => set({ isDialogOpen: open }),
   resetEditor: () => set({ content: "", title: "", thumbnail: null }),
+  // handleCancel 함수 - setImage를 매개변수로 받아 사용
+  handleCancel: (setImage) => {
+    const { content, title, toggleDialog, resetEditor, toggleEditor } = get();
+
+    if ((content.trim() && content.trim() !== "<p><br></p>") || title.trim()) {
+      toggleDialog(true);
+    } else {
+      resetEditor();
+      setImage(null); // 타입 에러 없이 사용 가능
+      toggleEditor();
+    }
+  },
 }));
 
 // 메인페이지 몇 시간? 클릭시 상호작용 기능


### PR DESCRIPTION
## 🪄 변경 사항

1**. 에디터에서 업로드한 이미지가 썸네일로 적용 가능합니다. (API 바인딩 완료)**
2. 파일 업로드를 위한 버튼 구현
3. 이미지 버튼에 따른 에디터 상태정리 완료.
4. 버튼 옆에 이미지 파일의 이름이 나옵니다. (2줄이상이면 ... 으로)
**5. placeholder 오류 수정.
커서의 위치가 맞지 않는 부분을 수정했습니다.
조합문자가 입력됐을 때, placeholder가 사라지지 않는 오류를 수정했습니다.**


## 💡 반영 브랜치

fix/editor-ImageBinding
픽스라고 생각했는데 feat이 맞는것 같습니다. 


## 🖼️ 결과 화면 (생략 가능)

![image](https://github.com/user-attachments/assets/c5f0e044-ed98-44f8-a224-01b80bbb933f)


## 💬 리뷰어에게 전할 말

파일 업로드 버튼의 위치가 애매할 수도 있습니다.
확인해주시고 좋은위치 찾으시면 알려주세요!

그 외에 자잘한 오류가 생기면 제보 부탁드립니다.

