### PR TITLE
✨ feat: 게시판 대체썸네일/프사 추가 + 본인 글이면 마이페이지로 연결 + 스크롤 수정 + 이미지 경로 수정

### DIFF
--- a/src/components/Community/PostPreview.tsx
+++ b/src/components/Community/PostPreview.tsx
@@ -2,14 +2,15 @@ import { Post_T, Title_T } from "../../api/api";
 import FavoriteIcon from "@mui/icons-material/Favorite";
 import ChatIcon from "@mui/icons-material/Chat";
 import { Link } from "react-router";
+import default_profile from "../../asset/default_profile.png";
+import default_thumbnail from "/src/asset/images/runtime_logo.svg"
 
 type Props = {
   preview: Post_T;
+  currentUser: string | null;
 };
 
-export default function PostPreview({ preview }: Props) {
-  const sampleImgUrl =
-    "https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcQdrgVj6z0tfzZSheYRKDWVUhB5zIkiZ9vUo6rFSULPgctqkQSmlkwfCDZ1RMHxgFF2XKIlAJb_28QzyZaR5s6zfQ";
+export default function PostPreview({ preview, currentUser }: Props) {
 
   // title 파싱한 객체(여기에 제목, 내용 들어가있고, 추후에 여러 컨텐츠들 추가할 예정 - 목표 달성 트로피 표시 등등)
   const parsedTitle: Title_T = JSON.parse(preview.title);
@@ -29,7 +30,7 @@ export default function PostPreview({ preview }: Props) {
       {/* 썸네일 이미지 */}
       <div className="relative aspect-video rounded-t-[10px] overflow-hidden">
         <img
-          src={preview.image ? preview.image : sampleImgUrl}
+          src={preview.image ? preview.image : default_thumbnail}
           alt={parsedTitle.title}
           className="object-cover w-full h-full"
         />
@@ -40,7 +41,7 @@ export default function PostPreview({ preview }: Props) {
           {parsedTitle.title}
         </h4>
         <div>
-          <p className="line-clamp-3 mb-6	text-sm text-[#495057] h-[3.93rem] ">
+          <p className="line-clamp-3 mb-6	text-sm text-[#495057] h-[3.9rem] ">
             {parsedTitle.content}
           </p>
         </div>
@@ -58,11 +59,19 @@ export default function PostPreview({ preview }: Props) {
         </div>
         <div className="flex items-center ">
           <Link
-            to={`/userpage/${preview.author.fullName}`}
+            to={
+              currentUser === preview.author.fullName
+                ? `/mypage`
+                : `/userpage/${preview.author.fullName}`
+            }
             className="flex items-center"
           >
             <img
-              src={preview.author.image}
+              src={
+                !preview.author.image || preview.author.image === ""
+                  ? default_profile
+                  : preview.author.image
+              }
               alt="글쓴이 프로필 이미지"
               className="w-6 h-6 rounded-full mr-2"
             />

--- a/src/components/Community/Skeleton.tsx
+++ b/src/components/Community/Skeleton.tsx
@@ -6,7 +6,7 @@ export default function Skeleton() {
       {/* 제목 및 내용 스켈레톤 */}
       <div className="px-4 py-5 h-[163px]">
         <div className="pt-1 h-4 bg-gray-300 rounded mb-2 w-3/4"></div>
-        <div className="space-y-2 h-[3.93rem] mb-7">
+        <div className="space-y-2 h-[3.9rem] mb-7">
           <div className="h-3 bg-gray-300 rounded w-full"></div>
           <div className="h-3 bg-gray-300 rounded w-full"></div>
           <div className="h-3 bg-gray-300 rounded w-5/6"></div>

--- a/src/routes/Join/Join.tsx
+++ b/src/routes/Join/Join.tsx
@@ -1,10 +1,11 @@
 import { useEffect, useState } from "react";
+import { useNavigate } from "react-router";
+import { axiosInstance } from "../../api/axios";
+import { Alert } from "@mui/material";
 import FormContainer from "../../components/Form/FormContainer";
 import Input from "../../components/Form/Input";
-import { useNavigate } from "react-router";
-import { Alert } from "@mui/material";
 import SubmitButton from "../../components/Form/SubmitButton";
-import { axiosInstance } from "../../api/axios";
+import runtime_logo from "/src/asset/images/runtime_logo.svg"
 
 export default function Join() {
   const [email, setEmail] = useState("");
@@ -166,7 +167,7 @@ export default function Join() {
       <FormContainer>
         <header className="flex justify-center items-center mt-8 mb-4">
           <img
-            src="/src/asset/images/runtime_logo.svg"
+            src={runtime_logo}
             alt="Runtime Logo"
             className="w-14 h-14"
           />

--- a/src/routes/Join/JoinSuccess.tsx
+++ b/src/routes/Join/JoinSuccess.tsx
@@ -1,6 +1,7 @@
 import { useNavigate } from "react-router";
 import FormContainer from "../../components/Form/FormContainer";
 import SubmitButton from "../../components/Form/SubmitButton";
+import runtime_logo from "/src/asset/images/runtime_logo.svg"
 
 export default function JoinSuccess() {
   const navigate = useNavigate();
@@ -11,7 +12,7 @@ export default function JoinSuccess() {
         <FormContainer>
           <header className="flex justify-center items-center mt-16 mb-10">
             <img
-              src="/src/asset/images/runtime_logo.svg"
+              src={runtime_logo}
               alt="Runtime Logo"
               className="w-36 h-36"
             />

--- a/src/routes/LayOut/CommunityLayout.tsx
+++ b/src/routes/LayOut/CommunityLayout.tsx
@@ -3,7 +3,7 @@ import Header from "./Header";
 
 export default function CommunityLayout() {
   return (
-    <main className="relative px-[50px] mx-auto s-core-dream-light max-w-[1440px] h-screen select-none overflow-y-auto custom-scroll">
+    <main className="relative px-[50px] mx-auto s-core-dream-light max-w-[1440px] h-screen select-none ">
       <Header />
       <Outlet />
     </main>

--- a/src/routes/Login/Login.tsx
+++ b/src/routes/Login/Login.tsx
@@ -1,11 +1,12 @@
 import { Alert } from "@mui/material";
 import { useEffect, useState } from "react";
 import { useNavigate } from "react-router";
+import { axiosInstance } from "../../api/axios";
+import { useLoginStore } from "../../store/API";
 import FormContainer from "../../components/Form/FormContainer";
 import Input from "../../components/Form/Input";
 import SubmitButton from "../../components/Form/SubmitButton";
-import { axiosInstance } from "../../api/axios";
-import { useLoginStore } from "../../store/API";
+import runtime_logo from "/src/asset/images/runtime_logo.svg"
 
 export default function Login() {
   const login = "로그인";
@@ -88,7 +89,7 @@ export default function Login() {
       <FormContainer>
         <header className="flex items-center justify-center mt-10 mb-4">
           <img
-            src="/src/asset/images/runtime_logo.svg"
+            src={runtime_logo}
             alt="Runtime Logo"
             className="w-16 h-16"
           />


### PR DESCRIPTION
## 🪄 변경 사항
게시글 미리보기에서 글쓴유저 프로필을 눌렀을 때 , 그 글이 본인(현재 로그인한 유저)이 작성한 글이면 본인의 마이페이지로 이동하도록 하였습니다
게시글 썸네일/작성자 프로필 사진이 없는 경우 대체이미지가 나오도록 하였습니다.
스크롤 윗부분 안 보이는 문제를 수정했습니다
이미지 경로를 수정했습니다

## 💡 반영 브랜치
feat/channel

## 🖼️ 결과 화면 (생략 가능)
![image](https://github.com/user-attachments/assets/6580500e-d9cf-4bc6-a859-60c374de46fa)

## 💬 리뷰어에게 전할 말
감사합니다! 수정사항 있으면 말씀해주세요