### PR TITLE
✨ feat: 마이페이지, 유저페이지 website 항목 하이퍼링크로 변환

### DIFF
--- a/src/components/Mypage/Input.tsx
+++ b/src/components/Mypage/Input.tsx
@@ -2,7 +2,7 @@ import React from "react";
 import { Stack } from "@mui/material";
 
 interface InputProps {
-  isEditable: boolean;
+  isEditable?: boolean;
   label: string;
   value: string;
   readonly?: boolean;
@@ -18,39 +18,73 @@ const Input = ({
 }: InputProps) => {
   const isRequiredProfile = ["이름", "별명"].includes(label);
 
+  const isWebsiteField = label === "Website";
+  const getWebsite = (value: string) => {
+    if (typeof value === "string" && value !== "-") {
+      return value.startsWith("http") ? value : `https://${value}`;
+    }
+    return null;
+  };
+  const link = getWebsite(value);
+
   return (
     <Stack direction="column" spacing={1}>
-      {/* 필드 라벨 */}
       <label
         htmlFor={`input-field-${label}`}
         style={{
           fontSize: "20px",
         }}
       >
-        {label}{" "}
+        {label}
         {isRequiredProfile && <span style={{ color: "#E14444" }}>*</span>}
       </label>
 
-      <input
-        id={`input-field-${label}`}
-        type="text"
-        disabled={!isEditable} // isEditable이 false일 때 비활성화
-        style={{
-          width: "37rem",
-          height: "3rem",
-          padding: "0.5rem 1rem",
-          backgroundColor: readonly ? "#e6e6e6" : "#F9F9F9",
-          border: isEditable ? "1px solid #ccc" : "none",
-          borderRadius: "10px",
-          outline: "none",
-          fontSize: "16px",
-          color: "#333",
-          marginBottom: "3rem",
-        }}
-        value={value}
-        onChange={onChange}
-        readOnly={readonly}
-      />
+      {!isEditable && isWebsiteField && link ? (
+        <a
+          href={link}
+          target="_blank"
+          rel="noopener noreferrer"
+          style={{
+            width: "37rem",
+            height: "3rem",
+            display: "flex",
+            alignItems: "center",
+            padding: "0.5rem 1rem",
+            backgroundColor: "#F9F9F9",
+            borderRadius: "10px",
+            fontSize: "16px",
+            color: "black",
+            textDecoration: "underline",
+            overflow: "hidden",
+            whiteSpace: "nowrap",
+            textOverflow: "ellipsis",
+            marginBottom: "3rem",
+          }}
+        >
+          {value}
+        </a>
+      ) : (
+        <input
+          id={`input-field-${label}`}
+          type="text"
+          disabled={!isEditable}
+          style={{
+            width: "37rem",
+            height: "3rem",
+            padding: "0.5rem 1rem",
+            backgroundColor: readonly ? "#e6e6e6" : "#F9F9F9",
+            border: isEditable ? "1px solid #ccc" : "none",
+            borderRadius: "10px",
+            outline: "none",
+            fontSize: "16px",
+            color: "#333",
+            marginBottom: "3rem",
+          }}
+          value={value}
+          onChange={onChange}
+          readOnly={readonly}
+        />
+      )}
     </Stack>
   );
 };


### PR DESCRIPTION
## 🪄 변경 사항
- 입력된 website 를 눌렀을 때  그 페이지가 새로운 창에서 열림
- http 으로 시작하지 않는 경우에는 website 앞에 https 를 붙여주고 정상적으로 작동 
- `<a>` 태그 `noopener noreferrer` 처리 

## 💡 반영 브랜치
- feat/link-website ➡️ main

## 🖼️ 결과 화면 (생략 가능)
<img width="958" alt="image" src="https://github.com/user-attachments/assets/78c9fde8-20d0-42c8-b259-40ab5ec911e4" />


## 💬 리뷰어에게 전할 말
-  오류 생기면 알려주세요! 🙏