### PR TITLE
💄 style: 런타임 로고를 마스코트 이미지로 대체

### DIFF
--- a/src/components/404Page/ErrorPage.tsx
+++ b/src/components/404Page/ErrorPage.tsx
@@ -1,17 +1,17 @@
 import { Link } from "react-router";
-import runtime_logo from "../../asset/images/runtime_logo.svg";
+import mascot_nobg from "../../asset/images/mascot_nobg.svg";
 
 export default function ErrorPage() {
   return (
     <>
       <main className="">
-        <section className="flex w-full h-screen justify-center items-center flex-col">
+        <section className="flex flex-col items-center justify-center w-full h-screen">
           <div className="flex">
             <span className="text-9xl text-[#C96868] font-bold">4</span>
             <img
-              src={runtime_logo}
+              src={mascot_nobg}
               alt="Runtime Logo"
-              className="w-36 h-36 mx-5"
+              className="mx-4 w-36 h-36"
             />
             <span className="text-9xl text-[#C96868] font-bold">4</span>
           </div>
@@ -21,7 +21,7 @@ export default function ErrorPage() {
               삭제되었거나 링크를 잘못 입력했습니다.
             </span>
           </div>
-          <div className="text-center items-center mt-6">
+          <div className="items-center mt-6 text-center">
             <Link to="/" className="text-lg">
               <button className="bg-[#C96868] w-44 h-12 text-white font-bold p-3 rounded-[7.49px]">
                 홈으로 돌아가기

--- a/src/components/Community/PostPreview.tsx
+++ b/src/components/Community/PostPreview.tsx
@@ -3,7 +3,7 @@ import FavoriteIcon from "@mui/icons-material/Favorite";
 import ChatIcon from "@mui/icons-material/Chat";
 import { Link } from "react-router";
 import default_profile from "../../asset/default_profile.png";
-import default_thumbnail from "/src/asset/images/runtime_logo.svg"
+import default_thumbnail from "/src/asset/images/mascot_nobg.svg";
 
 type Props = {
   preview: Post_T;
@@ -11,7 +11,6 @@ type Props = {
 };
 
 export default function PostPreview({ preview, currentUser }: Props) {
-
   // title 파싱한 객체(여기에 제목, 내용 들어가있고, 추후에 여러 컨텐츠들 추가할 예정 - 목표 달성 트로피 표시 등등)
   const parsedTitle: Title_T = JSON.parse(preview.title);
 
@@ -37,7 +36,7 @@ export default function PostPreview({ preview, currentUser }: Props) {
       </div>
       {/* 글 제목 및 내용 미리보기 */}
       <div className="p-4">
-        <h4 className="truncate mb-1 font-bold text-base">
+        <h4 className="mb-1 text-base font-bold truncate">
           {parsedTitle.title}
         </h4>
         <div>
@@ -73,7 +72,7 @@ export default function PostPreview({ preview, currentUser }: Props) {
                   : preview.author.image
               }
               alt="글쓴이 프로필 이미지"
-              className="w-6 h-6 rounded-full mr-2"
+              className="w-6 h-6 mr-2 rounded-full"
             />
             <span className="font-bold">{preview.author.fullName}</span>
           </Link>

--- a/src/routes/Join/Join.tsx
+++ b/src/routes/Join/Join.tsx
@@ -5,7 +5,7 @@ import { Alert } from "@mui/material";
 import FormContainer from "../../components/Form/FormContainer";
 import Input from "../../components/Form/Input";
 import SubmitButton from "../../components/Form/SubmitButton";
-import runtime_logo from "/src/asset/images/runtime_logo.svg"
+import mascot_nobg from "../../asset/images/mascot_nobg.svg";
 
 export default function Join() {
   const [email, setEmail] = useState("");
@@ -163,16 +163,12 @@ export default function Join() {
   }, [joinError]);
 
   return (
-    <main className="flex justify-center items-center">
+    <main className="flex items-center justify-center">
       <FormContainer>
-        <header className="flex justify-center items-center mt-8 mb-4">
-          <img
-            src={runtime_logo}
-            alt="Runtime Logo"
-            className="w-14 h-14"
-          />
+        <header className="flex items-center justify-center mt-8 mb-4">
+          <img src={mascot_nobg} alt="Runtime Logo" className="w-20 h-20" />
         </header>
-        <h1 className="text-2xl font-bold text-center mt-5">회원가입</h1>
+        <h1 className="mt-5 text-2xl font-bold text-center">회원가입</h1>
         <section className="mt-7">
           <Input
             label="이메일"

--- a/src/routes/Join/JoinSuccess.tsx
+++ b/src/routes/Join/JoinSuccess.tsx
@@ -1,21 +1,17 @@
 import { useNavigate } from "react-router";
 import FormContainer from "../../components/Form/FormContainer";
 import SubmitButton from "../../components/Form/SubmitButton";
-import runtime_logo from "/src/asset/images/runtime_logo.svg"
+import mascot_nobg from "../../asset/images/mascot_nobg.svg";
 
 export default function JoinSuccess() {
   const navigate = useNavigate();
 
   return (
     <>
-      <main className="flex justify-center items-center">
+      <main className="flex items-center justify-center">
         <FormContainer>
-          <header className="flex justify-center items-center mt-16 mb-10">
-            <img
-              src={runtime_logo}
-              alt="Runtime Logo"
-              className="w-36 h-36"
-            />
+          <header className="flex items-center justify-center mt-16 mb-6">
+            <img src={mascot_nobg} alt="Runtime Logo" className="w-40 h-40" />
           </header>
           <section>
             <p className="text-3xl font-bold text-center">가입을 축하합니다!</p>

--- a/src/routes/LayOut/Header.tsx
+++ b/src/routes/LayOut/Header.tsx
@@ -4,7 +4,7 @@ import { useprofileModalStore } from "../../store/store";
 import { useLoginStore } from "../../store/API";
 import { useNotificationsStore } from "../../store/notificationsStore";
 import Modal from "../../components/Modal/ProfileModal";
-import runtime from "../../asset/images/runtime_logo.svg";
+import mascot_nobg from "../../asset/images/mascot_nobg.svg";
 import bell from "../../asset/images/bell.svg";
 import default_bell from "../../asset/images/alarm_icon.svg";
 import default_profile from "../../asset/default_profile.png";
@@ -37,9 +37,9 @@ export default function Header() {
         <article className="flex items-center gap-[30px]">
           <Link to="/">
             <img
-              src={runtime}
-              alt={"런타임 로고"}
-              className="w-[40px] h-[40px] object-cover"
+              src={mascot_nobg}
+              alt={"mascot"}
+              className="object-cover w-12 h-12"
             />
           </Link>
           <Link
@@ -76,7 +76,7 @@ export default function Header() {
             <img
               src={user?.image ? user.image : default_profile}
               alt="유저 이미지 커버"
-              className="rounded-full w-full h-full object-cover"
+              className="object-cover w-full h-full rounded-full"
             />
           </button>
           {type === "header" && <Modal />}

--- a/src/routes/Login/Login.tsx
+++ b/src/routes/Login/Login.tsx
@@ -6,7 +6,7 @@ import { useLoginStore } from "../../store/API";
 import FormContainer from "../../components/Form/FormContainer";
 import Input from "../../components/Form/Input";
 import SubmitButton from "../../components/Form/SubmitButton";
-import runtime_logo from "/src/asset/images/runtime_logo.svg"
+import mascot_nobg from "/src/asset/images/mascot_nobg.svg";
 
 export default function Login() {
   const login = "로그인";
@@ -87,14 +87,10 @@ export default function Login() {
   return (
     <main className="flex items-center justify-center">
       <FormContainer>
-        <header className="flex items-center justify-center mt-10 mb-4">
-          <img
-            src={runtime_logo}
-            alt="Runtime Logo"
-            className="w-16 h-16"
-          />
+        <header className="flex items-center justify-center mt-10 mb-4 ">
+          <img src={mascot_nobg} alt="Mascot" className="w-20 h-20" />
         </header>
-        <h1 className="text-3xl font-bold text-center mt-7">로그인</h1>
+        <h1 className="mt-5 text-3xl font-bold text-center">로그인</h1>
 
         <section className="mt-10">
           <Input


### PR DESCRIPTION
## 🪄 변경 사항
- 런타임 로고를 마스코트 이미지로 대체 

## 💡 반영 브랜치
- style/mascot ➡️ main

## 🖼️ 결과 화면 (생략 가능)
<img width="1253" alt="image" src="https://github.com/user-attachments/assets/d127074e-815b-4be4-9650-a6f72c772483" />
<img width="1272" alt="image" src="https://github.com/user-attachments/assets/f16a81e5-5b71-4f03-9c80-d69f9c498f99" />


## 💬 리뷰어에게 전할 말
- 깨지는 부분이 있으면 알려주세요 ♪(´▽｀)
