### PR TITLE
feat: 상세페이지 버튼 컴포넌트,  좋아요/댓글/화면상단이동 버튼 세트 추가

### DIFF
--- a/src/components/Post/PostButton.tsx
+++ b/src/components/Post/PostButton.tsx
@@ -1,0 +1,21 @@
+import React from "react";
+interface PostButtonProps {
+  icon: string | React.ReactNode;
+  onClick: (event: React.MouseEvent<HTMLButtonElement>) => void;
+  className?: string;
+}
+
+export default function PostButton({
+  onClick,
+  icon,
+  className,
+}: PostButtonProps) {
+  return (
+    <button
+      className={`w-[52px] h-[52px] rounded-full bg-white ${className}`}
+      onClick={onClick}
+    >
+      {icon}
+    </button>
+  );
+}

--- a/src/components/Post/PostButtonFieldCol.tsx
+++ b/src/components/Post/PostButtonFieldCol.tsx
@@ -1,0 +1,81 @@
+import { Stack } from "@mui/material";
+import FavoriteBorderRoundedIcon from "@mui/icons-material/FavoriteBorderRounded";
+import FavoriteRoundedIcon from "@mui/icons-material/FavoriteRounded";
+import MessageOutlinedIcon from "@mui/icons-material/MessageOutlined";
+import VerticalAlignTopRoundedIcon from "@mui/icons-material/VerticalAlignTopRounded";
+import { useState } from "react";
+import PostButton from "./PostButton";
+
+export default function PostButtonFieldCol() {
+  const [isLikeButtonClicked, setIsLikeButtonClicked] = useState(false);
+  const handleClickLikeButton = () => {
+    setIsLikeButtonClicked(!isLikeButtonClicked);
+  };
+
+  const handleClickCommentButton = () => {
+    window.scrollTo({ top: document.body.scrollHeight, behavior: "smooth" });
+    console.log("comment button clicked");
+  };
+
+  const handleToTopButton = () => {
+    window.scrollTo({ top: 0, behavior: "smooth" });
+  };
+
+  return (
+    <>
+      <Stack
+        gap={2}
+        className="w-[72px] items-center h-[220px] justify-center rounded-full drop-shadow-lg"
+        style={{
+          position: "fixed",
+          right: "30px",
+          top: "50%",
+          transform: "translateY(-50%)",
+        }}
+      >
+        <PostButton
+          icon={
+            isLikeButtonClicked ? (
+              <FavoriteRoundedIcon
+                sx={{
+                  fontSize: "28px",
+                  color: "#C96868",
+                }}
+              />
+            ) : (
+              <FavoriteBorderRoundedIcon
+                sx={{
+                  fontSize: "28px",
+                  "&:hover": {
+                    color: "#C96868",
+                  },
+                }}
+              />
+            )
+          }
+          onClick={handleClickLikeButton}
+        />
+
+        <PostButton
+          icon={
+            <MessageOutlinedIcon
+              sx={{ fontSize: "28px" }}
+              className="hover:text-[#7eacb5]"
+            />
+          }
+          onClick={handleClickCommentButton}
+        />
+
+        <PostButton
+          icon={
+            <VerticalAlignTopRoundedIcon
+              sx={{ fontSize: "28px" }}
+              className="hover:text-[#888]"
+            />
+          }
+          onClick={handleToTopButton}
+        />
+      </Stack>
+    </>
+  );
+}

--- a/src/components/Post/PostButtonFieldRow.tsx
+++ b/src/components/Post/PostButtonFieldRow.tsx
@@ -1,0 +1,81 @@
+import { Stack } from "@mui/material";
+import FavoriteBorderRoundedIcon from "@mui/icons-material/FavoriteBorderRounded";
+import FavoriteRoundedIcon from "@mui/icons-material/FavoriteRounded";
+import MessageOutlinedIcon from "@mui/icons-material/MessageOutlined";
+import VerticalAlignTopRoundedIcon from "@mui/icons-material/VerticalAlignTopRounded";
+import { useState } from "react";
+import PostButton from "./PostButton";
+
+export default function PostButtonFieldRow() {
+  const [isLikeButtonClicked, setIsLikeButtonClicked] = useState(false);
+  const handleClickLikeButton = () => {
+    setIsLikeButtonClicked(!isLikeButtonClicked);
+  };
+
+  const handleClickCommentButton = () => {
+    window.scrollTo({ top: document.body.scrollHeight, behavior: "smooth" });
+    console.log("comment button clicked");
+  };
+
+  const handleToTopButton = () => {
+    window.scrollTo({ top: 0, behavior: "smooth" });
+  };
+
+  return (
+    <>
+      <Stack
+        direction={"row"}
+        gap={2}
+        className="w-[220px] items-center h-[72px] justify-center rounded-full drop-shadow-lg"
+        style={{
+          position: "fixed",
+          right: "15%",
+          top: "8%",
+        }}
+      >
+        <PostButton
+          icon={
+            isLikeButtonClicked ? (
+              <FavoriteRoundedIcon
+                sx={{
+                  fontSize: "28px",
+                  color: "#C96868",
+                }}
+              />
+            ) : (
+              <FavoriteBorderRoundedIcon
+                sx={{
+                  fontSize: "28px",
+                  "&:hover": {
+                    color: "#C96868",
+                  },
+                }}
+              />
+            )
+          }
+          onClick={handleClickLikeButton}
+        />
+
+        <PostButton
+          icon={
+            <MessageOutlinedIcon
+              sx={{ fontSize: "28px" }}
+              className="hover:text-[#7eacb5]"
+            />
+          }
+          onClick={handleClickCommentButton}
+        />
+
+        <PostButton
+          icon={
+            <VerticalAlignTopRoundedIcon
+              sx={{ fontSize: "28px" }}
+              className="hover:text-[#888]"
+            />
+          }
+          onClick={handleToTopButton}
+        />
+      </Stack>
+    </>
+  );
+}


### PR DESCRIPTION
## 🪄 변경 사항
- 상세페이지에 사용할 버튼 컴포넌트 추가 
- 버튼 세트 추가 (row 방향 버전, col 방향 버전 구분)
  - 좋아요 버튼 추가
  - 댓글 버튼 추가
  - 화면상단이동 버튼 추가

## 💡 반영 브랜치
- feat/post-button-field ➡️ main

## 🖼️ 결과 화면 (생략 가능)

<img width="80" alt="image" src="https://github.com/user-attachments/assets/93c84579-5986-4e2c-9338-d3d0877e311c" />
<br />
<img width="200" alt="image" src="https://github.com/user-attachments/assets/f9e7c000-3183-4209-a320-7bf1f6a8c3ae" />

## 💬 리뷰어에게 전할 말
╰(*°▽°*)╯